### PR TITLE
docs: add more docs on the security/threat model

### DIFF
--- a/src/protocol/gate.rs
+++ b/src/protocol/gate.rs
@@ -6,6 +6,15 @@
 //! byte or writes ALLOWED and delegates the rest of the stream to the
 //! [`Transfer`] concrete implementations.
 //!
+//! # Security
+//!
+//! Peer identity is authenticated by the QUIC/TLS 1.3 handshake before any
+//! application byte is exchanged. Each peer's [`EndpointId`] is their Ed25519
+//! public key; completing the handshake proves possession of the corresponding
+//! private key. By the time [`RingGate`] reads the resource id, the caller's
+//! identity is cryptographically guaranteed — it cannot be spoofed by a peer
+//! who does not hold the matching private key.
+//!
 //! # Extension point
 //!
 //! [`Transfer`] is the trait to implement when adding new resource kinds.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -9,6 +9,15 @@
 //! to at least one ring associated with that resource, or if the built-in open
 //! ring (`"open"`) is associated with it (which grants access to everyone).
 //!
+//! # Security model
+//!
+//! The registry enforces **what** is allowed: which peers may access which
+//! resources, as declared by the operator. It does not authenticate **who** is
+//! speaking — that is guaranteed by the transport layer (QUIC/TLS 1.3) before
+//! the gate ever consults the registry. Custom backend implementations can
+//! therefore trust that the [`EndpointId`] passed to [`Registry::is_allowed`]
+//! has already been verified.
+//!
 //! # Implementing a custom backend
 //!
 //! 1. Implement [`Registry`] for your storage type.


### PR DESCRIPTION
Closes #7 

- Add a `# Security` section in the header of `protocol/gate.rs`, the module where `conn.remote_id()` is called and where the security property actually holds, explaining that peer identity is authenticated by the QUIC/TLS handshake before any application logic runs, so EndpointId can be trusted unconditionally by the gate;
- Add a  note in the `registry.rs` module too (a note in the `Registry` part): the registry enforces what is allowed, the transport enforces who is speaking.

This keeps the separation of concerns, for any backend custom implementations.