### PR TITLE
Fix/5 generic resource id length on protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rings"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bao-tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "iroh-rings"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = ["Enrico Fusto"]
 license = "MIT"
 description = "Ring-based access control for resources over iroh protocols."
 repository = "https://github.com/rikettsie/iroh-rings"
-keywords = ["p2p", "access-control", "ring-authorization", "iroh", "hole-punching"]
+keywords = ["p2p", "access-control", "ring-authorization", "iroh", "holepunching"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can implement `Registry` in your concrete types directly, to use any other s
 `RingGate<R, T>` is an iroh `ProtocolHandler`. Wire protocol:
 
 ```text
-Initiator -> gate  [ 4 B]  u32-le: resource id length (N)
+Initiator -> gate  [ 2 B]  u16-le: resource id length (N)
                    [ N B]  resource id bytes
 Gate -> initiator  [ 1 B]  0x00 = DENIED  /  0x01 = ALLOWED
                    [rest]  sub-protocol defined by the Transfer implementor

--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ You can implement `Registry` in your concrete types directly, to use any other s
 `RingGate<R, T>` is an iroh `ProtocolHandler`. Wire protocol:
 
 ```text
-Initiator -> gate  [32 B]  resource id
+Initiator -> gate  [ 4 B]  u32-le: resource id length (N)
+                   [ N B]  resource id bytes
 Gate -> initiator  [ 1 B]  0x00 = DENIED  /  0x01 = ALLOWED
                    [rest]  sub-protocol defined by the Transfer implementor
 ```
 
-Wire the gate into an iroh `Router` using the provided `SC_ALPN` (`b"/iroh-rings/0"`):
+Wire the gate into an iroh `Router` using the provided `SC_ALPN` (`b"/iroh-rings/1"`):
 
 ```rust
 let gate = RingGate::new(registry, transfer);

--- a/src/protocol/gate.rs
+++ b/src/protocol/gate.rs
@@ -1,7 +1,7 @@
 //! [`RingGate`]: the iroh [`ProtocolHandler`] that enforces ring-based access control.
 //!
-//! When a peer opens a bi-directional stream, [`RingGate`] reads the 32-byte
-//! resource id, checks [`Registry::is_allowed`] (and [`Transfer::can_access`]
+//! When a peer opens a bi-directional stream, [`RingGate`] reads the
+//! length-prefixed resource id, checks [`Registry::is_allowed`] (and [`Transfer::can_access`]
 //! for application-level checks), then either closes the stream with a DENIED
 //! byte or writes ALLOWED and delegates the rest of the stream to the
 //! [`Transfer`] concrete implementations.
@@ -32,7 +32,7 @@ use tracing::{debug, info, warn};
 
 use crate::registry::Registry;
 
-use super::Status;
+use super::{Status, MAX_RESOURCE_ID_BYTES};
 
 /// Defines the sub-protocol that runs after the gate grants access.
 ///
@@ -57,7 +57,7 @@ pub trait Transfer: Clone + Send + Sync + 'static {
     /// Called after the gate has verified access.
     ///
     /// Both streams are fully handed over:
-    /// - `recv` contains whatever the initiator sent after the 32-byte resource id
+    /// - `recv` contains whatever the initiator sent after the resource id
     /// - `send` is ready for the implementor's response payload
     ///
     /// The gate writes the ALLOWED status byte before calling this; the implementor
@@ -122,12 +122,18 @@ impl<R: Registry + Clone + Send + Sync + 'static, T: Transfer> RingGate<R, T> {
         mut send: iroh::endpoint::SendStream,
         mut recv: iroh::endpoint::RecvStream,
     ) -> Result<()> {
-        let mut resource_id = [0u8; 32];
+        let mut len_buf = [0u8; std::mem::size_of::<u32>()];
+        recv.read_exact(&mut len_buf)
+            .await
+            .context("reading resource_id length")?;
+        let len = parse_resource_id_len(&len_buf)?;
+
+        let mut resource_id = vec![0u8; len];
         recv.read_exact(&mut resource_id)
             .await
             .context("reading resource_id")?;
 
-        debug!(%peer, resource_id = %hex::encode(resource_id), "request received");
+        debug!(%peer, resource_id = %hex::encode(&resource_id), "request received");
 
         let allowed = self
             .registry
@@ -136,14 +142,14 @@ impl<R: Registry + Clone + Send + Sync + 'static, T: Transfer> RingGate<R, T> {
             || self.transfer.can_access(&peer, &resource_id).await;
 
         if !allowed {
-            warn!(%peer, resource_id = %hex::encode(resource_id), "DENIED");
+            warn!(%peer, resource_id = %hex::encode(&resource_id), "DENIED");
             send.write_all(&[Status::Denied as u8]).await?;
             send.finish()?;
             return Ok(());
         }
 
         send.write_all(&[Status::Allowed as u8]).await?;
-        info!(%peer, resource_id = %hex::encode(resource_id), "TRANSFER ALLOWED");
+        info!(%peer, resource_id = %hex::encode(&resource_id), "TRANSFER ALLOWED");
 
         match self
             .transfer
@@ -152,14 +158,53 @@ impl<R: Registry + Clone + Send + Sync + 'static, T: Transfer> RingGate<R, T> {
         {
             Ok(()) => {
                 send.finish()?;
-                info!(%peer, resource_id = %hex::encode(resource_id), "TRANSFER COMPLETED");
+                info!(%peer, resource_id = %hex::encode(&resource_id), "TRANSFER COMPLETED");
             }
             Err(e) => {
-                warn!(%peer, resource_id = %hex::encode(resource_id), "TRANSFER FAILED");
+                warn!(%peer, resource_id = %hex::encode(&resource_id), "TRANSFER FAILED");
                 return Err(e).context("transfer failed");
             }
         }
 
         Ok(())
+    }
+}
+
+fn parse_resource_id_len(buf: &[u8; 4]) -> Result<usize> {
+    let len = u32::from_le_bytes(*buf) as usize;
+    anyhow::ensure!(
+        len <= MAX_RESOURCE_ID_BYTES,
+        "resource id length {len} exceeds maximum {MAX_RESOURCE_ID_BYTES}",
+    );
+    Ok(len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_resource_id_len_zero_is_valid() {
+        assert_eq!(parse_resource_id_len(&0u32.to_le_bytes()).unwrap(), 0);
+    }
+
+    #[test]
+    fn parse_resource_id_len_typical_is_valid() {
+        assert_eq!(parse_resource_id_len(&32u32.to_le_bytes()).unwrap(), 32);
+    }
+
+    #[test]
+    fn parse_resource_id_len_maximum_is_valid() {
+        let max = MAX_RESOURCE_ID_BYTES as u32;
+        assert_eq!(
+            parse_resource_id_len(&max.to_le_bytes()).unwrap(),
+            MAX_RESOURCE_ID_BYTES,
+        );
+    }
+
+    #[test]
+    fn parse_resource_id_len_exceeding_maximum_errors() {
+        let over = (MAX_RESOURCE_ID_BYTES + 1) as u32;
+        assert!(parse_resource_id_len(&over.to_le_bytes()).is_err());
     }
 }

--- a/src/protocol/gate.rs
+++ b/src/protocol/gate.rs
@@ -122,7 +122,7 @@ impl<R: Registry + Clone + Send + Sync + 'static, T: Transfer> RingGate<R, T> {
         mut send: iroh::endpoint::SendStream,
         mut recv: iroh::endpoint::RecvStream,
     ) -> Result<()> {
-        let mut len_buf = [0u8; std::mem::size_of::<u32>()];
+        let mut len_buf = [0u8; std::mem::size_of::<u16>()];
         recv.read_exact(&mut len_buf)
             .await
             .context("reading resource_id length")?;
@@ -170,8 +170,8 @@ impl<R: Registry + Clone + Send + Sync + 'static, T: Transfer> RingGate<R, T> {
     }
 }
 
-fn parse_resource_id_len(buf: &[u8; 4]) -> Result<usize> {
-    let len = u32::from_le_bytes(*buf) as usize;
+fn parse_resource_id_len(buf: &[u8; 2]) -> Result<usize> {
+    let len = u16::from_le_bytes(*buf) as usize;
     anyhow::ensure!(
         len <= MAX_RESOURCE_ID_BYTES,
         "resource id length {len} exceeds maximum {MAX_RESOURCE_ID_BYTES}",
@@ -185,17 +185,17 @@ mod tests {
 
     #[test]
     fn parse_resource_id_len_zero_is_valid() {
-        assert_eq!(parse_resource_id_len(&0u32.to_le_bytes()).unwrap(), 0);
+        assert_eq!(parse_resource_id_len(&0u16.to_le_bytes()).unwrap(), 0);
     }
 
     #[test]
     fn parse_resource_id_len_typical_is_valid() {
-        assert_eq!(parse_resource_id_len(&32u32.to_le_bytes()).unwrap(), 32);
+        assert_eq!(parse_resource_id_len(&32u16.to_le_bytes()).unwrap(), 32);
     }
 
     #[test]
     fn parse_resource_id_len_maximum_is_valid() {
-        let max = MAX_RESOURCE_ID_BYTES as u32;
+        let max = MAX_RESOURCE_ID_BYTES as u16;
         assert_eq!(
             parse_resource_id_len(&max.to_le_bytes()).unwrap(),
             MAX_RESOURCE_ID_BYTES,
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn parse_resource_id_len_exceeding_maximum_errors() {
-        let over = (MAX_RESOURCE_ID_BYTES + 1) as u32;
+        let over = (MAX_RESOURCE_ID_BYTES + 1) as u16;
         assert!(parse_resource_id_len(&over.to_le_bytes()).is_err());
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! ```text
 //! Request (initiator peer -> gate)
-//!  [ 4 B]  u32-le: resource id length (N)
+//!  [ 2 B]  u16-le: resource id length (N)
 //!  [ N B]  resource id bytes
 //!
 //! Response (gate -> initiator peer)
@@ -28,7 +28,7 @@ pub const MAX_RESOURCE_ID_BYTES: usize = 256;
 
 /// Encodes a resource id request for sending to a [`RingGate`].
 ///
-/// Writes `[u32-le length][resource_id bytes]` into a new buffer.
+/// Writes `[u16-le length][resource_id bytes]` into a new buffer.
 ///
 /// # Errors
 ///
@@ -40,8 +40,8 @@ pub fn encode_request(resource_id: &[u8]) -> anyhow::Result<Vec<u8>> {
         resource_id.len(),
         MAX_RESOURCE_ID_BYTES,
     );
-    let len = resource_id.len() as u32;
-    let mut out = Vec::with_capacity(std::mem::size_of::<u32>() + resource_id.len());
+    let len = resource_id.len() as u16;
+    let mut out = Vec::with_capacity(std::mem::size_of::<u16>() + resource_id.len());
     out.extend_from_slice(&len.to_le_bytes());
     out.extend_from_slice(resource_id);
     Ok(out)
@@ -90,26 +90,26 @@ mod tests {
     #[test]
     fn encode_request_empty_resource_id_writes_zero_length_header() {
         let encoded = encode_request(&[]).unwrap();
-        assert_eq!(encoded.len(), 4);
-        assert_eq!(u32::from_le_bytes(encoded[..4].try_into().unwrap()), 0);
+        assert_eq!(encoded.len(), 2);
+        assert_eq!(u16::from_le_bytes(encoded[..2].try_into().unwrap()), 0);
     }
 
     #[test]
     fn encode_request_32_byte_id_round_trips() {
         let id = [0xabu8; 32];
         let encoded = encode_request(&id).unwrap();
-        let len = u32::from_le_bytes(encoded[..4].try_into().unwrap()) as usize;
+        let len = u16::from_le_bytes(encoded[..2].try_into().unwrap()) as usize;
         assert_eq!(len, 32);
-        assert_eq!(&encoded[4..], &id);
+        assert_eq!(&encoded[2..], &id);
     }
 
     #[test]
     fn encode_request_16_byte_id_round_trips() {
         let id = [0x42u8; 16];
         let encoded = encode_request(&id).unwrap();
-        let len = u32::from_le_bytes(encoded[..4].try_into().unwrap()) as usize;
+        let len = u16::from_le_bytes(encoded[..2].try_into().unwrap()) as usize;
         assert_eq!(len, 16);
-        assert_eq!(&encoded[4..], &id);
+        assert_eq!(&encoded[2..], &id);
     }
 
     #[test]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,10 +1,11 @@
-//! Wire protocol for `/iroh-rings/0`.
+//! Wire protocol for `/iroh-rings/1`.
 //!
 //! # Wire protocol
 //!
 //! ```text
 //! Request (initiator peer -> gate)
-//!  [32 B]  resource id: identifies the resource being requested
+//!  [ 4 B]  u32-le: resource id length (N)
+//!  [ N B]  resource id bytes
 //!
 //! Response (gate -> initiator peer)
 //!  [ 1 B]  status: 0x00 = DENIED, 0x01 = ALLOWED
@@ -17,7 +18,34 @@ mod gate;
 
 pub use gate::{RingGate, Transfer};
 
-pub const SC_ALPN: &[u8] = b"/iroh-rings/0";
+pub const SC_ALPN: &[u8] = b"/iroh-rings/1";
+
+/// Maximum number of bytes accepted for a resource id on the wire.
+///
+/// Enforced by the gate before any allocation so a malicious peer cannot
+/// trigger an unbounded allocation by sending a large length field.
+pub const MAX_RESOURCE_ID_BYTES: usize = 256;
+
+/// Encodes a resource id request for sending to a [`RingGate`].
+///
+/// Writes `[u32-le length][resource_id bytes]` into a new buffer.
+///
+/// # Errors
+///
+/// Returns an error if `resource_id.len()` exceeds [`MAX_RESOURCE_ID_BYTES`].
+pub fn encode_request(resource_id: &[u8]) -> anyhow::Result<Vec<u8>> {
+    anyhow::ensure!(
+        resource_id.len() <= MAX_RESOURCE_ID_BYTES,
+        "resource id length {} exceeds maximum {}",
+        resource_id.len(),
+        MAX_RESOURCE_ID_BYTES,
+    );
+    let len = resource_id.len() as u32;
+    let mut out = Vec::with_capacity(std::mem::size_of::<u32>() + resource_id.len());
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(resource_id);
+    Ok(out)
+}
 
 /// Gate response byte sent to the initiator after a resource request.
 #[repr(u8)]
@@ -57,5 +85,42 @@ mod tests {
     fn status_unknown_byte_errors() {
         assert!(Status::try_from(0x02).is_err());
         assert!(Status::try_from(0xff).is_err());
+    }
+
+    #[test]
+    fn encode_request_empty_resource_id_writes_zero_length_header() {
+        let encoded = encode_request(&[]).unwrap();
+        assert_eq!(encoded.len(), 4);
+        assert_eq!(u32::from_le_bytes(encoded[..4].try_into().unwrap()), 0);
+    }
+
+    #[test]
+    fn encode_request_32_byte_id_round_trips() {
+        let id = [0xabu8; 32];
+        let encoded = encode_request(&id).unwrap();
+        let len = u32::from_le_bytes(encoded[..4].try_into().unwrap()) as usize;
+        assert_eq!(len, 32);
+        assert_eq!(&encoded[4..], &id);
+    }
+
+    #[test]
+    fn encode_request_16_byte_id_round_trips() {
+        let id = [0x42u8; 16];
+        let encoded = encode_request(&id).unwrap();
+        let len = u32::from_le_bytes(encoded[..4].try_into().unwrap()) as usize;
+        assert_eq!(len, 16);
+        assert_eq!(&encoded[4..], &id);
+    }
+
+    #[test]
+    fn encode_request_rejects_oversized_resource_id() {
+        let id = vec![0u8; MAX_RESOURCE_ID_BYTES + 1];
+        assert!(encode_request(&id).is_err());
+    }
+
+    #[test]
+    fn encode_request_accepts_maximum_size_resource_id() {
+        let id = vec![0u8; MAX_RESOURCE_ID_BYTES];
+        assert!(encode_request(&id).is_ok());
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -44,6 +44,12 @@ impl ResourceId for [u8; 32] {
     }
 }
 
+impl ResourceId for Vec<u8> {
+    fn as_bytes(&self) -> &[u8] {
+        self
+    }
+}
+
 /// Manages rings, their peer membership, and the association between
 /// resources and rings.
 ///


### PR DESCRIPTION
Closes #5

The generic length of `ResourceId` at wire level, is introduced in the protocol v1 (`/iroh-rings/1`).
A guard for maximum length is enforced in the request handler function.