### PR TITLE
feat!: replace anyhow with typed Error across public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,6 +1821,7 @@ dependencies = [
  "serde",
  "serde_millis",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ fs = ["dep:iroh-blobs", "dep:iroh-io", "dep:bytes", "dep:futures-lite", "dep:bao
 [dependencies]
 iroh = "0.98.2"
 anyhow = "1"
+thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 serde_millis = "0.1.1"
 tokio = { version = "1", features = ["rt", "sync"] }

--- a/src/backends/memory.rs
+++ b/src/backends/memory.rs
@@ -8,11 +8,11 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use anyhow::{anyhow, Result};
 use iroh::EndpointId;
 
 use crate::registry::{Registry, ResourceId};
 use crate::ring::{Ring, OPEN_RING_NAME};
+use crate::Error;
 
 #[derive(Default)]
 struct Inner {
@@ -48,14 +48,14 @@ impl InMemoryRegistry {
 }
 
 impl Registry for InMemoryRegistry {
-    fn create_ring(&self, ring_name: &str) -> Result<()> {
+    fn create_ring(&self, ring_name: &str) -> Result<(), Error> {
         let ring = Ring::new(ring_name)?;
         if ring.is_open() {
-            return Err(anyhow!("'{}' is a reserved ring name", OPEN_RING_NAME));
+            return Err(Error::RingNameReserved(OPEN_RING_NAME.to_string()));
         }
         let mut inner = self.inner.write().unwrap();
         if inner.rings.contains_key(ring_name) {
-            return Err(anyhow!("ring '{}' already exists", ring_name));
+            return Err(Error::RingAlreadyExists(ring_name.to_string()));
         }
         inner.rings.insert(ring_name.to_string(), Vec::new());
         Ok(())
@@ -66,12 +66,12 @@ impl Registry for InMemoryRegistry {
         ring_name: &str,
         peer: EndpointId,
         nickname: Option<&str>,
-    ) -> Result<()> {
+    ) -> Result<(), Error> {
         let mut inner = self.inner.write().unwrap();
         let members = inner
             .rings
             .get_mut(ring_name)
-            .ok_or_else(|| anyhow!("ring '{}' not found", ring_name))?;
+            .ok_or_else(|| Error::RingNotFound(ring_name.to_string()))?;
         let peer_bytes = *peer.as_bytes();
         if !members.contains(&peer_bytes) {
             members.push(peer_bytes);
@@ -84,35 +84,36 @@ impl Registry for InMemoryRegistry {
         Ok(())
     }
 
-    fn remove_peer_from_ring(&self, ring_name: &str, peer: EndpointId) -> Result<()> {
+    fn remove_peer_from_ring(&self, ring_name: &str, peer: EndpointId) -> Result<(), Error> {
         let mut inner = self.inner.write().unwrap();
         let members = inner
             .rings
             .get_mut(ring_name)
-            .ok_or_else(|| anyhow!("ring '{}' not found", ring_name))?;
+            .ok_or_else(|| Error::RingNotFound(ring_name.to_string()))?;
         let peer_bytes = *peer.as_bytes();
         members.retain(|b| b != &peer_bytes);
         inner.nicknames.remove(&(ring_name.to_string(), peer_bytes));
         Ok(())
     }
 
-    fn list_ring_peers(&self, ring_name: &str) -> Result<Vec<(EndpointId, Option<String>)>> {
+    fn list_ring_peers(&self, ring_name: &str) -> Result<Vec<(EndpointId, Option<String>)>, Error> {
         let inner = self.inner.read().unwrap();
         let members = inner
             .rings
             .get(ring_name)
-            .ok_or_else(|| anyhow!("ring '{}' not found", ring_name))?;
+            .ok_or_else(|| Error::RingNotFound(ring_name.to_string()))?;
         members
             .iter()
             .map(|b| {
-                let peer = EndpointId::from_bytes(b).map_err(|e| anyhow!("{e}"))?;
+                let peer = EndpointId::from_bytes(b)
+                    .map_err(|e| Error::Storage(Box::new(std::io::Error::other(e.to_string()))))?;
                 let nick = inner.nicknames.get(&(ring_name.to_string(), *b)).cloned();
                 Ok((peer, nick))
             })
             .collect()
     }
 
-    fn list_rings(&self) -> Result<Vec<Ring>> {
+    fn list_rings(&self) -> Result<Vec<Ring>, Error> {
         let inner = self.inner.read().unwrap();
         let mut rings = vec![Ring::new_open()];
         for name in inner.rings.keys() {
@@ -123,7 +124,10 @@ impl Registry for InMemoryRegistry {
         Ok(rings)
     }
 
-    fn remove_ring_from_resource<ResId: ResourceId>(&self, resource_id: ResId) -> Result<()> {
+    fn remove_ring_from_resource<ResId: ResourceId>(
+        &self,
+        resource_id: ResId,
+    ) -> Result<(), Error> {
         self.inner
             .write()
             .unwrap()
@@ -132,7 +136,10 @@ impl Registry for InMemoryRegistry {
         Ok(())
     }
 
-    fn list_resource_rings<ResId: ResourceId>(&self, resource_id: ResId) -> Result<Vec<Ring>> {
+    fn list_resource_rings<ResId: ResourceId>(
+        &self,
+        resource_id: ResId,
+    ) -> Result<Vec<Ring>, Error> {
         let inner = self.inner.read().unwrap();
         Ok(inner
             .resource_rings
@@ -150,25 +157,14 @@ impl Registry for InMemoryRegistry {
         &self,
         resource_id: ResId,
         ring_name: &str,
-    ) -> Result<()> {
+    ) -> Result<(), Error> {
         let mut inner = self.inner.write().unwrap();
         if !inner.rings.contains_key(ring_name) {
-            return Err(anyhow!("ring '{}' not found", ring_name));
+            return Err(Error::RingNotFound(ring_name.to_string()));
         }
         let key = resource_id.as_bytes().to_vec();
         let existing = inner.resource_rings.get(&key).cloned().unwrap_or_default();
-        let names = if ring_name == OPEN_RING_NAME {
-            vec![OPEN_RING_NAME.to_string()]
-        } else {
-            let mut kept: Vec<String> = existing
-                .into_iter()
-                .filter(|n| n != OPEN_RING_NAME)
-                .collect();
-            if !kept.iter().any(|n| n == ring_name) {
-                kept.push(ring_name.to_string());
-            }
-            kept
-        };
+        let names = crate::registry::compute_resource_rings(existing, ring_name);
         inner.resource_rings.insert(key, names);
         Ok(())
     }
@@ -177,7 +173,7 @@ impl Registry for InMemoryRegistry {
         &self,
         peer: &EndpointId,
         resource_id: &ResId,
-    ) -> Result<bool> {
+    ) -> Result<bool, Error> {
         let inner = self.inner.read().unwrap();
         let ring_names = match inner.resource_rings.get(resource_id.as_bytes()) {
             None => return Ok(false),
@@ -206,297 +202,8 @@ mod tests {
     use super::*;
     use crate::registry::registry_contract;
 
-    fn make_reg() -> InMemoryRegistry {
-        InMemoryRegistry::new()
-    }
-
     #[test]
     fn satisfies_registry_contract() {
-        registry_contract(&make_reg());
-    }
-
-    fn make_resource(b: u8) -> [u8; 32] {
-        [b; 32]
-    }
-
-    fn make_peer() -> EndpointId {
-        iroh::SecretKey::generate().public()
-    }
-
-    // add_ring_to_resource
-
-    #[test]
-    fn associating_open_ring_clears_private_rings() {
-        let reg = make_reg();
-        let resource = make_resource(1);
-        reg.create_ring("friends").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        reg.add_ring_to_resource(resource, OPEN_RING_NAME).unwrap();
-        let rings = reg.list_resource_rings(resource).unwrap();
-        assert_eq!(rings, vec![Ring::new_open()]);
-    }
-
-    #[test]
-    fn associating_private_ring_clears_open_ring() {
-        let reg = make_reg();
-        let resource = make_resource(1);
-        reg.create_ring("friends").unwrap();
-        reg.add_ring_to_resource(resource, OPEN_RING_NAME).unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        let rings = reg.list_resource_rings(resource).unwrap();
-        assert_eq!(rings, vec![Ring::new("friends").unwrap()]);
-    }
-
-    #[test]
-    fn associating_private_ring_is_idempotent() {
-        let reg = make_reg();
-        let resource = make_resource(1);
-        reg.create_ring("friends").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        assert_eq!(reg.list_resource_rings(resource).unwrap().len(), 1);
-    }
-
-    #[test]
-    fn associating_multiple_private_rings_accumulate() {
-        let reg = make_reg();
-        let resource = make_resource(1);
-        reg.create_ring("friends").unwrap();
-        reg.create_ring("work").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        reg.add_ring_to_resource(resource, "work").unwrap();
-        let rings = reg.list_resource_rings(resource).unwrap();
-        assert_eq!(rings.len(), 2);
-        assert!(rings.contains(&Ring::new("friends").unwrap()));
-        assert!(rings.contains(&Ring::new("work").unwrap()));
-    }
-
-    #[test]
-    fn associating_resource_rejects_nonexistent_ring() {
-        let reg = make_reg();
-        assert!(reg.add_ring_to_resource(make_resource(1), "ghost").is_err());
-    }
-
-    // list_resource_rings
-
-    #[test]
-    fn resource_with_no_associations_returns_empty_rings() {
-        let reg = make_reg();
-        assert_eq!(reg.list_resource_rings(make_resource(1)).unwrap(), vec![]);
-    }
-
-    // create_ring
-
-    #[test]
-    fn create_ring_rejects_reserved_name() {
-        let reg = make_reg();
-        assert!(reg.create_ring(OPEN_RING_NAME).is_err());
-    }
-
-    #[test]
-    fn create_ring_rejects_duplicate() {
-        let reg = make_reg();
-        reg.create_ring("friends").unwrap();
-        assert!(reg.create_ring("friends").is_err());
-    }
-
-    #[test]
-    fn create_ring_rejects_empty_name() {
-        let reg = make_reg();
-        assert!(reg.create_ring("").is_err());
-    }
-
-    #[test]
-    fn create_ring_rejects_name_with_whitespace() {
-        let reg = make_reg();
-        assert!(reg.create_ring("my ring").is_err());
-        assert!(reg.create_ring("tab\there").is_err());
-    }
-
-    #[test]
-    fn create_ring_rejects_name_with_nul() {
-        let reg = make_reg();
-        assert!(reg.create_ring("ring\0name").is_err());
-    }
-
-    // list_rings
-
-    #[test]
-    fn list_rings_always_includes_open_ring() {
-        let reg = make_reg();
-        let rings = reg.list_rings().unwrap();
-        assert_eq!(rings[0], Ring::new_open());
-    }
-
-    #[test]
-    fn list_rings_returns_all_created_rings() {
-        let reg = make_reg();
-        reg.create_ring("friends").unwrap();
-        reg.create_ring("work").unwrap();
-        let rings = reg.list_rings().unwrap();
-        assert!(rings.contains(&Ring::new("friends").unwrap()));
-        assert!(rings.contains(&Ring::new("work").unwrap()));
-        assert_eq!(rings.len(), 3);
-    }
-
-    // add_peer_to_ring / remove_peer_from_ring
-
-    #[test]
-    fn add_member_is_idempotent() {
-        let reg = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_peer_to_ring("friends", peer, None).unwrap();
-        reg.add_peer_to_ring("friends", peer, None).unwrap();
-        assert_eq!(reg.list_ring_peers("friends").unwrap().len(), 1);
-    }
-
-    #[test]
-    fn add_member_to_nonexistent_ring_errors() {
-        let reg = make_reg();
-        assert!(reg.add_peer_to_ring("ghost", make_peer(), None).is_err());
-    }
-
-    #[test]
-    fn remove_member_from_nonexistent_ring_errors() {
-        let reg = make_reg();
-        assert!(reg.remove_peer_from_ring("ghost", make_peer()).is_err());
-    }
-
-    #[test]
-    fn remove_member_noop_when_peer_not_in_ring() {
-        let reg = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.remove_peer_from_ring("friends", peer).unwrap();
-        assert_eq!(reg.list_ring_peers("friends").unwrap().len(), 0);
-    }
-
-    // list_ring_peers
-
-    #[test]
-    fn list_members_nonexistent_ring_errors() {
-        let reg = make_reg();
-        assert!(reg.list_ring_peers("ghost").is_err());
-    }
-
-    // is_allowed
-
-    #[test]
-    fn is_allowed_unassociated_resource_denied() {
-        let reg = make_reg();
-        let peer = make_peer();
-        assert!(!reg.is_allowed(&peer, &make_resource(1)).unwrap());
-    }
-
-    #[test]
-    fn is_allowed_open_ring_permits_any_peer() {
-        let reg = make_reg();
-        let resource = make_resource(1);
-        let peer = make_peer();
-        reg.add_ring_to_resource(resource, OPEN_RING_NAME).unwrap();
-        assert!(reg.is_allowed(&peer, &resource).unwrap());
-    }
-
-    #[test]
-    fn is_allowed_member_of_ring_permitted() {
-        let reg = make_reg();
-        let resource = make_resource(1);
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        reg.add_peer_to_ring("friends", peer, None).unwrap();
-        assert!(reg.is_allowed(&peer, &resource).unwrap());
-    }
-
-    #[test]
-    fn is_allowed_non_member_denied() {
-        let reg = make_reg();
-        let resource = make_resource(1);
-        let member = make_peer();
-        let stranger = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        reg.add_peer_to_ring("friends", member, None).unwrap();
-        assert!(!reg.is_allowed(&stranger, &resource).unwrap());
-    }
-
-    #[test]
-    fn is_allowed_peer_in_one_of_multiple_rings_permitted() {
-        let reg = make_reg();
-        let resource = make_resource(1);
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.create_ring("work").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        reg.add_ring_to_resource(resource, "work").unwrap();
-        reg.add_peer_to_ring("work", peer, None).unwrap();
-        assert!(reg.is_allowed(&peer, &resource).unwrap());
-    }
-
-    // nicknames
-
-    #[test]
-    fn nickname_stored_and_returned_by_list_members() {
-        let reg = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_peer_to_ring("friends", peer, Some("alice"))
-            .unwrap();
-        let members = reg.list_ring_peers("friends").unwrap();
-        assert_eq!(members.len(), 1);
-        assert_eq!(members[0].1.as_deref(), Some("alice"));
-    }
-
-    #[test]
-    fn no_nickname_returns_none() {
-        let reg = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_peer_to_ring("friends", peer, None).unwrap();
-        let members = reg.list_ring_peers("friends").unwrap();
-        assert_eq!(members[0].1, None);
-    }
-
-    #[test]
-    fn nickname_updated_on_readd() {
-        let reg = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_peer_to_ring("friends", peer, Some("alice"))
-            .unwrap();
-        reg.add_peer_to_ring("friends", peer, Some("alice2"))
-            .unwrap();
-        let members = reg.list_ring_peers("friends").unwrap();
-        assert_eq!(members.len(), 1);
-        assert_eq!(members[0].1.as_deref(), Some("alice2"));
-    }
-
-    #[test]
-    fn nickname_removed_with_peer() {
-        let reg = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_peer_to_ring("friends", peer, Some("alice"))
-            .unwrap();
-        reg.remove_peer_from_ring("friends", peer).unwrap();
-        reg.add_peer_to_ring("friends", peer, None).unwrap();
-        let members = reg.list_ring_peers("friends").unwrap();
-        assert_eq!(members[0].1, None);
-    }
-
-    #[test]
-    fn nicknames_are_per_ring() {
-        let reg = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.create_ring("work").unwrap();
-        reg.add_peer_to_ring("friends", peer, Some("alice"))
-            .unwrap();
-        reg.add_peer_to_ring("work", peer, Some("bob")).unwrap();
-        let friends = reg.list_ring_peers("friends").unwrap();
-        let work = reg.list_ring_peers("work").unwrap();
-        assert_eq!(friends[0].1.as_deref(), Some("alice"));
-        assert_eq!(work[0].1.as_deref(), Some("bob"));
+        registry_contract(&InMemoryRegistry::new());
     }
 }

--- a/src/backends/redb.rs
+++ b/src/backends/redb.rs
@@ -19,12 +19,17 @@
 
 use std::{path::Path, sync::Arc};
 
-use anyhow::{anyhow, Result};
 use iroh::EndpointId;
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 
 use crate::registry::{Registry, ResourceId};
 use crate::ring::{Ring, OPEN_RING_NAME};
+use crate::Error;
+
+/// Wraps any storage-level error into [`Error::Storage`].
+fn storage<E: std::error::Error + Send + Sync + 'static>(e: E) -> Error {
+    Error::Storage(Box::new(e))
+}
 
 /// Maps ring name (&str) to serialised Vec<[u8; 32]> of member peer-ids.
 const RINGS: TableDefinition<&str, &[u8]> = TableDefinition::new("rings");
@@ -46,38 +51,42 @@ impl RedbRegistry {
     /// Open (or create) the registry at `path`.
     ///
     /// On first creation the open ring is bootstrapped automatically.
-    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
-        let db = Database::create(path)?;
-        let write = db.begin_write()?;
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, Error> {
+        let db = Database::create(path).map_err(storage)?;
+        let write = db.begin_write().map_err(storage)?;
         {
-            let mut rings = write.open_table(RINGS)?;
-            write.open_table(RESOURCE_RINGS)?;
-            write.open_table(NICKNAMES)?;
+            let mut rings = write.open_table(RINGS).map_err(storage)?;
+            write.open_table(RESOURCE_RINGS).map_err(storage)?;
+            write.open_table(NICKNAMES).map_err(storage)?;
 
-            if rings.get(OPEN_RING_NAME)?.is_none() {
-                rings.insert(OPEN_RING_NAME, encode_peer_ids(&[]).as_slice())?;
+            if rings.get(OPEN_RING_NAME).map_err(storage)?.is_none() {
+                rings
+                    .insert(OPEN_RING_NAME, encode_peer_ids(&[]).as_slice())
+                    .map_err(storage)?;
             }
         }
-        write.commit()?;
+        write.commit().map_err(storage)?;
         Ok(Self { db: Arc::new(db) })
     }
 }
 
 impl Registry for RedbRegistry {
-    fn create_ring(&self, ring_name: &str) -> Result<()> {
+    fn create_ring(&self, ring_name: &str) -> Result<(), Error> {
         let ring = Ring::new(ring_name)?;
         if ring.is_open() {
-            return Err(anyhow!("'{}' is a reserved ring name", ring_name));
+            return Err(Error::RingNameReserved(OPEN_RING_NAME.to_string()));
         }
-        let write = self.db.begin_write()?;
+        let write = self.db.begin_write().map_err(storage)?;
         {
-            let mut table = write.open_table(RINGS)?;
-            if table.get(ring_name)?.is_some() {
-                return Err(anyhow!("ring '{}' already exists", ring_name));
+            let mut table = write.open_table(RINGS).map_err(storage)?;
+            if table.get(ring_name).map_err(storage)?.is_some() {
+                return Err(Error::RingAlreadyExists(ring_name.to_string()));
             }
-            table.insert(ring_name, encode_peer_ids(&[]).as_slice())?;
+            table
+                .insert(ring_name, encode_peer_ids(&[]).as_slice())
+                .map_err(storage)?;
         }
-        write.commit()?;
+        write.commit().map_err(storage)?;
         Ok(())
     }
 
@@ -86,60 +95,71 @@ impl Registry for RedbRegistry {
         ring_name: &str,
         peer: EndpointId,
         nickname: Option<&str>,
-    ) -> Result<()> {
-        let write = self.db.begin_write()?;
+    ) -> Result<(), Error> {
+        let write = self.db.begin_write().map_err(storage)?;
         {
-            let mut table = write.open_table(RINGS)?;
-            let mut members = match table.get(ring_name)? {
+            let mut table = write.open_table(RINGS).map_err(storage)?;
+            let mut members = match table.get(ring_name).map_err(storage)? {
                 Some(v) => decode_peer_ids(v.value()),
-                None => return Err(anyhow!("ring '{}' not found", ring_name)),
+                None => return Err(Error::RingNotFound(ring_name.to_string())),
             };
             let peer_bytes = *peer.as_bytes();
             if !members.contains(&peer_bytes) {
                 members.push(peer_bytes);
             }
-            table.insert(ring_name, encode_peer_ids(&members).as_slice())?;
+            table
+                .insert(ring_name, encode_peer_ids(&members).as_slice())
+                .map_err(storage)?;
 
             if let Some(nick) = nickname {
-                let mut nick_table = write.open_table(NICKNAMES)?;
-                nick_table.insert(nickname_key(ring_name, &peer).as_slice(), nick)?;
+                let mut nick_table = write.open_table(NICKNAMES).map_err(storage)?;
+                nick_table
+                    .insert(nickname_key(ring_name, &peer).as_slice(), nick)
+                    .map_err(storage)?;
             }
         }
-        write.commit()?;
+        write.commit().map_err(storage)?;
         Ok(())
     }
 
-    fn remove_peer_from_ring(&self, ring_name: &str, peer: EndpointId) -> Result<()> {
-        let write = self.db.begin_write()?;
+    fn remove_peer_from_ring(&self, ring_name: &str, peer: EndpointId) -> Result<(), Error> {
+        let write = self.db.begin_write().map_err(storage)?;
         {
-            let mut table = write.open_table(RINGS)?;
-            let mut members = match table.get(ring_name)? {
+            let mut table = write.open_table(RINGS).map_err(storage)?;
+            let mut members = match table.get(ring_name).map_err(storage)? {
                 Some(v) => decode_peer_ids(v.value()),
-                None => return Err(anyhow!("ring '{}' not found", ring_name)),
+                None => return Err(Error::RingNotFound(ring_name.to_string())),
             };
             let peer_bytes = *peer.as_bytes();
             members.retain(|b| b != &peer_bytes);
-            table.insert(ring_name, encode_peer_ids(&members).as_slice())?;
+            table
+                .insert(ring_name, encode_peer_ids(&members).as_slice())
+                .map_err(storage)?;
 
-            let mut nick_table = write.open_table(NICKNAMES)?;
-            nick_table.remove(nickname_key(ring_name, &peer).as_slice())?;
+            let mut nick_table = write.open_table(NICKNAMES).map_err(storage)?;
+            nick_table
+                .remove(nickname_key(ring_name, &peer).as_slice())
+                .map_err(storage)?;
         }
-        write.commit()?;
+        write.commit().map_err(storage)?;
         Ok(())
     }
 
-    fn list_ring_peers(&self, ring_name: &str) -> Result<Vec<(EndpointId, Option<String>)>> {
-        let read = self.db.begin_read()?;
-        let table = read.open_table(RINGS)?;
-        let nick_table = read.open_table(NICKNAMES)?;
-        match table.get(ring_name)? {
-            None => Err(anyhow!("ring '{}' not found", ring_name)),
+    fn list_ring_peers(&self, ring_name: &str) -> Result<Vec<(EndpointId, Option<String>)>, Error> {
+        let read = self.db.begin_read().map_err(storage)?;
+        let table = read.open_table(RINGS).map_err(storage)?;
+        let nick_table = read.open_table(NICKNAMES).map_err(storage)?;
+        match table.get(ring_name).map_err(storage)? {
+            None => Err(Error::RingNotFound(ring_name.to_string())),
             Some(v) => decode_peer_ids(v.value())
                 .into_iter()
                 .map(|b| {
-                    let peer = EndpointId::from_bytes(&b).map_err(|e| anyhow!("{e}"))?;
+                    let peer = EndpointId::from_bytes(&b).map_err(|e| {
+                        Error::Storage(Box::new(std::io::Error::other(e.to_string())))
+                    })?;
                     let nick = nick_table
-                        .get(nickname_key(ring_name, &peer).as_slice())?
+                        .get(nickname_key(ring_name, &peer).as_slice())
+                        .map_err(storage)?
                         .map(|v| v.value().to_owned());
                     Ok((peer, nick))
                 })
@@ -147,12 +167,12 @@ impl Registry for RedbRegistry {
         }
     }
 
-    fn list_rings(&self) -> Result<Vec<Ring>> {
-        let read = self.db.begin_read()?;
-        let table = read.open_table(RINGS)?;
+    fn list_rings(&self) -> Result<Vec<Ring>, Error> {
+        let read = self.db.begin_read().map_err(storage)?;
+        let table = read.open_table(RINGS).map_err(storage)?;
         let mut ids = vec![Ring::new_open()];
-        for entry in table.iter()? {
-            let (k, _) = entry?;
+        for entry in table.iter().map_err(storage)? {
+            let (k, _) = entry.map_err(storage)?;
             let name = k.value().to_owned();
             if name != OPEN_RING_NAME {
                 ids.push(Ring::new(name).expect("invariant: db ring names are always valid"));
@@ -161,20 +181,26 @@ impl Registry for RedbRegistry {
         Ok(ids)
     }
 
-    fn remove_ring_from_resource<ResId: ResourceId>(&self, resource_id: ResId) -> Result<()> {
-        let write = self.db.begin_write()?;
+    fn remove_ring_from_resource<ResId: ResourceId>(
+        &self,
+        resource_id: ResId,
+    ) -> Result<(), Error> {
+        let write = self.db.begin_write().map_err(storage)?;
         {
-            let mut table = write.open_table(RESOURCE_RINGS)?;
-            table.remove(resource_id.as_bytes())?;
+            let mut table = write.open_table(RESOURCE_RINGS).map_err(storage)?;
+            table.remove(resource_id.as_bytes()).map_err(storage)?;
         }
-        write.commit()?;
+        write.commit().map_err(storage)?;
         Ok(())
     }
 
-    fn list_resource_rings<ResId: ResourceId>(&self, resource_id: ResId) -> Result<Vec<Ring>> {
-        let read = self.db.begin_read()?;
-        let table = read.open_table(RESOURCE_RINGS)?;
-        match table.get(resource_id.as_bytes())? {
+    fn list_resource_rings<ResId: ResourceId>(
+        &self,
+        resource_id: ResId,
+    ) -> Result<Vec<Ring>, Error> {
+        let read = self.db.begin_read().map_err(storage)?;
+        let table = read.open_table(RESOURCE_RINGS).map_err(storage)?;
+        match table.get(resource_id.as_bytes()).map_err(storage)? {
             None => Ok(Vec::new()),
             Some(v) => Ok(decode_ring_names(v.value())
                 .into_iter()
@@ -189,38 +215,28 @@ impl Registry for RedbRegistry {
         &self,
         resource_id: ResId,
         ring_name: &str,
-    ) -> Result<()> {
-        let write = self.db.begin_write()?;
+    ) -> Result<(), Error> {
+        let write = self.db.begin_write().map_err(storage)?;
         {
-            let rings_table = write.open_table(RINGS)?;
-            if rings_table.get(ring_name)?.is_none() {
-                return Err(anyhow!("ring '{}' not found", ring_name));
+            let rings_table = write.open_table(RINGS).map_err(storage)?;
+            if rings_table.get(ring_name).map_err(storage)?.is_none() {
+                return Err(Error::RingNotFound(ring_name.to_string()));
             }
             drop(rings_table); // redb only allows one open at a time
 
-            let mut table = write.open_table(RESOURCE_RINGS)?;
+            let mut table = write.open_table(RESOURCE_RINGS).map_err(storage)?;
             let key = resource_id.as_bytes();
-            let existing = match table.get(key)? {
+            let existing = match table.get(key).map_err(storage)? {
                 Some(v) => decode_ring_names(v.value()),
                 None => Vec::new(),
             };
 
-            let names = if ring_name == OPEN_RING_NAME {
-                vec![OPEN_RING_NAME.to_owned()]
-            } else {
-                let mut kept: Vec<String> = existing
-                    .into_iter()
-                    .filter(|n| n != OPEN_RING_NAME)
-                    .collect();
-                if !kept.iter().any(|n| n == ring_name) {
-                    kept.push(ring_name.to_owned());
-                }
-                kept
-            };
-
-            table.insert(key, encode_ring_names(&names).as_slice())?;
+            let names = crate::registry::compute_resource_rings(existing, ring_name);
+            table
+                .insert(key, encode_ring_names(&names).as_slice())
+                .map_err(storage)?;
         }
-        write.commit()?;
+        write.commit().map_err(storage)?;
         Ok(())
     }
 
@@ -228,11 +244,11 @@ impl Registry for RedbRegistry {
         &self,
         peer: &EndpointId,
         resource_id: &ResId,
-    ) -> Result<bool> {
-        let read = self.db.begin_read()?;
+    ) -> Result<bool, Error> {
+        let read = self.db.begin_read().map_err(storage)?;
 
-        let fr_table = read.open_table(RESOURCE_RINGS)?;
-        let ring_names = match fr_table.get(resource_id.as_bytes())? {
+        let fr_table = read.open_table(RESOURCE_RINGS).map_err(storage)?;
+        let ring_names = match fr_table.get(resource_id.as_bytes()).map_err(storage)? {
             None => return Ok(false),
             Some(v) => decode_ring_names(v.value()),
         };
@@ -243,10 +259,10 @@ impl Registry for RedbRegistry {
             return Ok(true);
         }
 
-        let r_table = read.open_table(RINGS)?;
+        let r_table = read.open_table(RINGS).map_err(storage)?;
         let peer_bytes = *peer.as_bytes();
         for name in &ring_names {
-            if let Some(members_raw) = r_table.get(name.as_str())? {
+            if let Some(members_raw) = r_table.get(name.as_str()).map_err(storage)? {
                 let members = decode_peer_ids(members_raw.value());
                 if members.iter().any(|b| b == &peer_bytes) {
                     return Ok(true);
@@ -300,316 +316,10 @@ mod tests {
     use crate::registry::registry_contract;
     use tempfile::tempdir;
 
-    fn make_reg() -> (RedbRegistry, tempfile::TempDir) {
-        let dir = tempdir().unwrap();
-        let reg = RedbRegistry::open(dir.path().join("test.redb")).unwrap();
-        (reg, dir)
-    }
-
     #[test]
     fn satisfies_registry_contract() {
-        let (reg, _dir) = make_reg();
+        let dir = tempdir().unwrap();
+        let reg = RedbRegistry::open(dir.path().join("test.redb")).unwrap();
         registry_contract(&reg);
-    }
-
-    fn make_resource(b: u8) -> [u8; 32] {
-        [b; 32]
-    }
-
-    fn make_peer() -> EndpointId {
-        iroh::SecretKey::generate().public()
-    }
-
-    // add_ring_to_resource
-
-    #[test]
-    fn associating_open_ring_clears_private_rings() {
-        let (reg, _dir) = make_reg();
-        let resource = make_resource(1);
-        reg.create_ring("friends").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        reg.add_ring_to_resource(resource, OPEN_RING_NAME).unwrap();
-        let rings = reg.list_resource_rings(resource).unwrap();
-        assert_eq!(rings, vec![Ring::new_open()]);
-    }
-
-    #[test]
-    fn associating_private_ring_clears_open_ring() {
-        let (reg, _dir) = make_reg();
-        let resource = make_resource(1);
-        reg.create_ring("friends").unwrap();
-        reg.add_ring_to_resource(resource, OPEN_RING_NAME).unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        let rings = reg.list_resource_rings(resource).unwrap();
-        assert_eq!(rings, vec![Ring::new("friends").unwrap()]);
-    }
-
-    #[test]
-    fn associating_private_ring_is_idempotent() {
-        let (reg, _dir) = make_reg();
-        let resource = make_resource(1);
-        reg.create_ring("friends").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        assert_eq!(reg.list_resource_rings(resource).unwrap().len(), 1);
-    }
-
-    #[test]
-    fn associating_multiple_private_rings_accumulate() {
-        let (reg, _dir) = make_reg();
-        let resource = make_resource(1);
-        reg.create_ring("friends").unwrap();
-        reg.create_ring("work").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        reg.add_ring_to_resource(resource, "work").unwrap();
-        let rings = reg.list_resource_rings(resource).unwrap();
-        assert_eq!(rings.len(), 2);
-        assert!(rings.contains(&Ring::new("friends").unwrap()));
-        assert!(rings.contains(&Ring::new("work").unwrap()));
-    }
-
-    #[test]
-    fn associating_resource_rejects_nonexistent_ring() {
-        let (reg, _dir) = make_reg();
-        assert!(reg.add_ring_to_resource(make_resource(1), "ghost").is_err());
-    }
-
-    // list_resource_rings
-
-    #[test]
-    fn resource_with_no_associations_returns_empty_rings() {
-        let (reg, _dir) = make_reg();
-        assert_eq!(reg.list_resource_rings(make_resource(1)).unwrap(), vec![]);
-    }
-
-    // create_ring
-
-    #[test]
-    fn create_ring_rejects_reserved_name() {
-        let (reg, _dir) = make_reg();
-        assert!(reg.create_ring(OPEN_RING_NAME).is_err());
-    }
-
-    #[test]
-    fn create_ring_rejects_duplicate() {
-        let (reg, _dir) = make_reg();
-        reg.create_ring("friends").unwrap();
-        assert!(reg.create_ring("friends").is_err());
-    }
-
-    #[test]
-    fn create_ring_rejects_empty_name() {
-        let (reg, _dir) = make_reg();
-        assert!(reg.create_ring("").is_err());
-    }
-
-    #[test]
-    fn create_ring_rejects_name_with_whitespace() {
-        let (reg, _dir) = make_reg();
-        assert!(reg.create_ring("my ring").is_err());
-        assert!(reg.create_ring("tab\there").is_err());
-    }
-
-    #[test]
-    fn create_ring_rejects_name_with_nul() {
-        let (reg, _dir) = make_reg();
-        assert!(reg.create_ring("ring\0name").is_err());
-    }
-
-    // list_rings
-
-    #[test]
-    fn list_rings_always_includes_open_ring() {
-        let (reg, _dir) = make_reg();
-        let rings = reg.list_rings().unwrap();
-        assert_eq!(rings[0], Ring::new_open());
-    }
-
-    #[test]
-    fn list_rings_returns_all_created_rings() {
-        let (reg, _dir) = make_reg();
-        reg.create_ring("friends").unwrap();
-        reg.create_ring("work").unwrap();
-        let rings = reg.list_rings().unwrap();
-        assert!(rings.contains(&Ring::new("friends").unwrap()));
-        assert!(rings.contains(&Ring::new("work").unwrap()));
-        assert_eq!(rings.len(), 3);
-    }
-
-    // add_peer_to_ring / remove_peer_from_ring
-
-    #[test]
-    fn add_member_is_idempotent() {
-        let (reg, _dir) = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_peer_to_ring("friends", peer, None).unwrap();
-        reg.add_peer_to_ring("friends", peer, None).unwrap();
-        assert_eq!(reg.list_ring_peers("friends").unwrap().len(), 1);
-    }
-
-    #[test]
-    fn add_member_to_nonexistent_ring_errors() {
-        let (reg, _dir) = make_reg();
-        assert!(reg.add_peer_to_ring("ghost", make_peer(), None).is_err());
-    }
-
-    #[test]
-    fn remove_member_from_nonexistent_ring_errors() {
-        let (reg, _dir) = make_reg();
-        assert!(reg.remove_peer_from_ring("ghost", make_peer()).is_err());
-    }
-
-    #[test]
-    fn remove_member_noop_when_peer_not_in_ring() {
-        let (reg, _dir) = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.remove_peer_from_ring("friends", peer).unwrap();
-        assert_eq!(reg.list_ring_peers("friends").unwrap().len(), 0);
-    }
-
-    // list_ring_peers
-
-    #[test]
-    fn list_members_nonexistent_ring_errors() {
-        let (reg, _dir) = make_reg();
-        assert!(reg.list_ring_peers("ghost").is_err());
-    }
-
-    // is_allowed
-
-    #[test]
-    fn is_allowed_unassociated_resource_denied() {
-        let (reg, _dir) = make_reg();
-        let peer = make_peer();
-        assert!(!reg.is_allowed(&peer, &make_resource(1)).unwrap());
-    }
-
-    #[test]
-    fn is_allowed_open_ring_permits_any_peer() {
-        let (reg, _dir) = make_reg();
-        let resource = make_resource(1);
-        let peer = make_peer();
-        reg.add_ring_to_resource(resource, OPEN_RING_NAME).unwrap();
-        assert!(reg.is_allowed(&peer, &resource).unwrap());
-    }
-
-    #[test]
-    fn is_allowed_member_of_ring_permitted() {
-        let (reg, _dir) = make_reg();
-        let resource = make_resource(1);
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        reg.add_peer_to_ring("friends", peer, None).unwrap();
-        assert!(reg.is_allowed(&peer, &resource).unwrap());
-    }
-
-    #[test]
-    fn is_allowed_non_member_denied() {
-        let (reg, _dir) = make_reg();
-        let resource = make_resource(1);
-        let member = make_peer();
-        let stranger = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        reg.add_peer_to_ring("friends", member, None).unwrap();
-        assert!(!reg.is_allowed(&stranger, &resource).unwrap());
-    }
-
-    #[test]
-    fn is_allowed_peer_in_one_of_multiple_rings_permitted() {
-        let (reg, _dir) = make_reg();
-        let resource = make_resource(1);
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.create_ring("work").unwrap();
-        reg.add_ring_to_resource(resource, "friends").unwrap();
-        reg.add_ring_to_resource(resource, "work").unwrap();
-        reg.add_peer_to_ring("work", peer, None).unwrap();
-        assert!(reg.is_allowed(&peer, &resource).unwrap());
-    }
-
-    // nicknames
-
-    #[test]
-    fn nickname_stored_and_returned_by_list_members() {
-        let (reg, _dir) = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_peer_to_ring("friends", peer, Some("alice"))
-            .unwrap();
-        let members = reg.list_ring_peers("friends").unwrap();
-        assert_eq!(members.len(), 1);
-        assert_eq!(members[0].1.as_deref(), Some("alice"));
-    }
-
-    #[test]
-    fn no_nickname_returns_none() {
-        let (reg, _dir) = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_peer_to_ring("friends", peer, None).unwrap();
-        let members = reg.list_ring_peers("friends").unwrap();
-        assert_eq!(members[0].1, None);
-    }
-
-    #[test]
-    fn nickname_updated_on_readd() {
-        let (reg, _dir) = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_peer_to_ring("friends", peer, Some("alice"))
-            .unwrap();
-        reg.add_peer_to_ring("friends", peer, Some("alice2"))
-            .unwrap();
-        let members = reg.list_ring_peers("friends").unwrap();
-        assert_eq!(members.len(), 1);
-        assert_eq!(members[0].1.as_deref(), Some("alice2"));
-    }
-
-    #[test]
-    fn nickname_removed_with_peer() {
-        let (reg, _dir) = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_peer_to_ring("friends", peer, Some("alice"))
-            .unwrap();
-        reg.remove_peer_from_ring("friends", peer).unwrap();
-        reg.add_peer_to_ring("friends", peer, None).unwrap();
-        let members = reg.list_ring_peers("friends").unwrap();
-        assert_eq!(members[0].1, None);
-    }
-
-    #[test]
-    fn nicknames_are_per_ring() {
-        let (reg, _dir) = make_reg();
-        let peer = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.create_ring("work").unwrap();
-        reg.add_peer_to_ring("friends", peer, Some("alice"))
-            .unwrap();
-        reg.add_peer_to_ring("work", peer, Some("bob")).unwrap();
-        let friends = reg.list_ring_peers("friends").unwrap();
-        let work = reg.list_ring_peers("work").unwrap();
-        assert_eq!(friends[0].1.as_deref(), Some("alice"));
-        assert_eq!(work[0].1.as_deref(), Some("bob"));
-    }
-
-    #[test]
-    fn members_mixed_nicknames_and_none() {
-        let (reg, _dir) = make_reg();
-        let alice = make_peer();
-        let bob = make_peer();
-        reg.create_ring("friends").unwrap();
-        reg.add_peer_to_ring("friends", alice, Some("alice"))
-            .unwrap();
-        reg.add_peer_to_ring("friends", bob, None).unwrap();
-        let members = reg.list_ring_peers("friends").unwrap();
-        assert_eq!(members.len(), 2);
-        let nicks: Vec<_> = members.iter().map(|(_, n)| n.as_deref()).collect();
-        assert!(nicks.contains(&Some("alice")));
-        assert!(nicks.contains(&None));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,38 @@
+//! Public error type for iroh-rings.
+
+/// All errors that can be returned by the iroh-rings public API.
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Ring name must not be empty.
+    #[error("ring name must not be empty")]
+    RingNameEmpty,
+
+    /// Ring name must not contain whitespace or NUL bytes.
+    #[error("ring name must not contain whitespace or NUL bytes")]
+    RingNameInvalidChars,
+
+    /// The ring name is reserved by the implementation and cannot be used by callers.
+    #[error("'{0}' is a reserved ring name")]
+    RingNameReserved(String),
+
+    /// A ring with this name already exists.
+    #[error("ring '{0}' already exists")]
+    RingAlreadyExists(String),
+
+    /// No ring with this name was found in the registry.
+    #[error("ring '{0}' not found")]
+    RingNotFound(String),
+
+    /// The resource id is longer than the protocol maximum.
+    #[error("resource id length {0} exceeds maximum")]
+    ResourceIdTooLong(usize),
+
+    /// A status byte received on the wire was not recognised.
+    #[error("unexpected status byte: {0:#04x}")]
+    UnknownStatusByte(u8),
+
+    /// An underlying storage backend returned an error.
+    #[error("storage error: {0}")]
+    Storage(Box<dyn std::error::Error + Send + Sync + 'static>),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod protocol;
 pub mod registry;
 
@@ -9,6 +10,7 @@ pub mod transfers;
 
 mod ring;
 
+pub use error::Error;
 pub use registry::{Registry, ResourceId};
 pub use ring::{Ring, OPEN_RING_NAME};
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -33,13 +33,10 @@ pub const MAX_RESOURCE_ID_BYTES: usize = 256;
 /// # Errors
 ///
 /// Returns an error if `resource_id.len()` exceeds [`MAX_RESOURCE_ID_BYTES`].
-pub fn encode_request(resource_id: &[u8]) -> anyhow::Result<Vec<u8>> {
-    anyhow::ensure!(
-        resource_id.len() <= MAX_RESOURCE_ID_BYTES,
-        "resource id length {} exceeds maximum {}",
-        resource_id.len(),
-        MAX_RESOURCE_ID_BYTES,
-    );
+pub fn encode_request(resource_id: &[u8]) -> Result<Vec<u8>, crate::Error> {
+    if resource_id.len() > MAX_RESOURCE_ID_BYTES {
+        return Err(crate::Error::ResourceIdTooLong(resource_id.len()));
+    }
     let len = resource_id.len() as u16;
     let mut out = Vec::with_capacity(std::mem::size_of::<u16>() + resource_id.len());
     out.extend_from_slice(&len.to_le_bytes());
@@ -57,12 +54,12 @@ pub enum Status {
 }
 
 impl TryFrom<u8> for Status {
-    type Error = anyhow::Error;
-    fn try_from(b: u8) -> anyhow::Result<Self> {
+    type Error = crate::Error;
+    fn try_from(b: u8) -> Result<Self, crate::Error> {
         match b {
             0x00 => Ok(Status::Denied),
             0x01 => Ok(Status::Allowed),
-            _ => Err(anyhow::anyhow!("unexpected status byte: 0x{b:02x}")),
+            _ => Err(crate::Error::UnknownStatusByte(b)),
         }
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -23,10 +23,10 @@
 //! 1. Implement [`Registry`] for your storage type.
 //! 2. Run [`registry_contract`] in your test suite to verify behavioural correctness.
 
-use anyhow::Result;
 use iroh::EndpointId;
 
-use crate::ring::Ring;
+use crate::ring::{Ring, OPEN_RING_NAME};
+use crate::Error;
 
 /// A type that identifies a resource by a byte sequence,
 /// which is supposed to be unique.
@@ -62,7 +62,7 @@ pub trait Registry {
     /// Creates a new ring with the given name.
     ///
     /// Fails if the name is reserved (`"open"`) or already in use.
-    fn create_ring(&self, ring_name: &str) -> Result<()>;
+    fn create_ring(&self, ring_name: &str) -> Result<(), Error>;
 
     /// Adds a peer to a ring.
     ///
@@ -73,44 +73,69 @@ pub trait Registry {
         ring_name: &str,
         peer: EndpointId,
         nickname: Option<&str>,
-    ) -> Result<()>;
+    ) -> Result<(), Error>;
 
     /// Removes a peer from a ring.
-    fn remove_peer_from_ring(&self, ring_name: &str, peer: EndpointId) -> Result<()>;
+    fn remove_peer_from_ring(&self, ring_name: &str, peer: EndpointId) -> Result<(), Error>;
 
     /// Returns all `(peer, nickname)` pairs in the ring.
-    fn list_ring_peers(&self, ring_name: &str) -> Result<Vec<(EndpointId, Option<String>)>>;
+    fn list_ring_peers(&self, ring_name: &str) -> Result<Vec<(EndpointId, Option<String>)>, Error>;
 
     /// Returns all rings, including the built-in open ring.
-    fn list_rings(&self) -> Result<Vec<Ring>>;
+    fn list_rings(&self) -> Result<Vec<Ring>, Error>;
 
     /// Removes all rings from a resource, revoking access for all peers.
-    fn remove_ring_from_resource<ResId: ResourceId>(&self, resource_id: ResId) -> Result<()>;
+    fn remove_ring_from_resource<ResId: ResourceId>(&self, resource_id: ResId)
+        -> Result<(), Error>;
 
     /// Returns the rings currently associated with a resource.
-    fn list_resource_rings<ResId: ResourceId>(&self, resource_id: ResId) -> Result<Vec<Ring>>;
+    fn list_resource_rings<ResId: ResourceId>(
+        &self,
+        resource_id: ResId,
+    ) -> Result<Vec<Ring>, Error>;
 
     /// Associate a resource with a ring, granting ring members access to it.
     fn add_ring_to_resource<ResId: ResourceId>(
         &self,
         resource_id: ResId,
         ring_name: &str,
-    ) -> Result<()>;
+    ) -> Result<(), Error>;
 
     /// Returns `true` if `peer` is allowed to access `resource_id`.
     ///
     /// A peer is allowed if it belongs to at least one ring associated with the
     /// resource, or if the open ring is associated with it.
-    fn is_allowed<ResId: ResourceId>(&self, peer: &EndpointId, resource_id: &ResId)
-        -> Result<bool>;
+    fn is_allowed<ResId: ResourceId>(
+        &self,
+        peer: &EndpointId,
+        resource_id: &ResId,
+    ) -> Result<bool, Error>;
+}
+
+/// Compute the updated ring list when associating `ring_name` with a resource.
+///
+/// If `ring_name` is [`OPEN_RING_NAME`], all private rings are replaced with only
+/// the open ring. Otherwise, the open ring is removed and `ring_name` is appended
+/// if not already present.
+pub fn compute_resource_rings(existing: Vec<String>, ring_name: &str) -> Vec<String> {
+    if ring_name == OPEN_RING_NAME {
+        vec![OPEN_RING_NAME.to_string()]
+    } else {
+        let mut kept: Vec<String> = existing
+            .into_iter()
+            .filter(|n| n != OPEN_RING_NAME)
+            .collect();
+        if !kept.iter().any(|n| n == ring_name) {
+            kept.push(ring_name.to_string());
+        }
+        kept
+    }
 }
 
 /// Shared contract test, to be run against every [`Registry`] implementation:
-/// each assertion enforce the behaviour all backends must satisfy.
+/// each assertion enforces the behaviour all backends must satisfy.
 #[cfg(test)]
 pub fn registry_contract<R: Registry>(reg: &R) {
-    use crate::ring::OPEN_RING_NAME;
-
     fn make_resource(b: u8) -> [u8; 32] {
         [b; 32]
     }
@@ -118,11 +143,10 @@ pub fn registry_contract<R: Registry>(reg: &R) {
         iroh::SecretKey::generate().public()
     }
 
-    // list_rings always includes the open ring
-    let rings = reg.list_rings().unwrap();
-    assert!(rings.iter().any(|r| r.is_open()));
+    // --- list_rings / create_ring ---
 
-    // create_ring / list_rings
+    assert!(reg.list_rings().unwrap().iter().any(|r| r.is_open()));
+
     reg.create_ring("friends").unwrap();
     assert!(reg
         .list_rings()
@@ -130,13 +154,21 @@ pub fn registry_contract<R: Registry>(reg: &R) {
         .iter()
         .any(|r| r.as_str() == "friends"));
 
-    // duplicate ring is rejected
-    assert!(reg.create_ring("friends").is_err());
+    assert!(reg.create_ring("friends").is_err()); // duplicate rejected
+    assert!(reg.create_ring(OPEN_RING_NAME).is_err()); // reserved name rejected
+    assert!(reg.create_ring("").is_err()); // empty name rejected
+    assert!(reg.create_ring("my ring").is_err()); // whitespace rejected
+    assert!(reg.create_ring("tab\there").is_err());
+    assert!(reg.create_ring("ring\0name").is_err()); // nul rejected
 
-    // reserved name is rejected
-    assert!(reg.create_ring(OPEN_RING_NAME).is_err());
+    reg.create_ring("work").unwrap();
+    let rings = reg.list_rings().unwrap();
+    assert!(rings.iter().any(|r| r.as_str() == "friends"));
+    assert!(rings.iter().any(|r| r.as_str() == "work"));
+    assert_eq!(rings.len(), 3); // open + friends + work
 
-    // add_peer_to_ring / list_ring_peers
+    // --- add_peer_to_ring / remove_peer_from_ring / list_ring_peers ---
+
     let alice = make_peer();
     reg.add_peer_to_ring("friends", alice, Some("alice"))
         .unwrap();
@@ -144,34 +176,167 @@ pub fn registry_contract<R: Registry>(reg: &R) {
     assert_eq!(peers.len(), 1);
     assert_eq!(peers[0].1.as_deref(), Some("alice"));
 
-    // add_peer is idempotent
-    reg.add_peer_to_ring("friends", alice, None).unwrap();
+    reg.add_peer_to_ring("friends", alice, None).unwrap(); // idempotent
     assert_eq!(reg.list_ring_peers("friends").unwrap().len(), 1);
 
-    // remove_peer_from_ring
     reg.remove_peer_from_ring("friends", alice).unwrap();
     assert_eq!(reg.list_ring_peers("friends").unwrap().len(), 0);
 
-    // resource with no ring associations denies everyone
+    assert!(reg.add_peer_to_ring("ghost", make_peer(), None).is_err());
+    assert!(reg.remove_peer_from_ring("ghost", make_peer()).is_err());
+    assert!(reg.list_ring_peers("ghost").is_err());
+
+    let extra = make_peer();
+    reg.remove_peer_from_ring("friends", extra).unwrap(); // noop when not a member
+    assert_eq!(reg.list_ring_peers("friends").unwrap().len(), 0);
+
+    // --- is_allowed ---
+
     let resource = make_resource(0xab);
     let bob = make_peer();
-    assert!(!reg.is_allowed(&bob, &resource).unwrap());
+    assert!(!reg.is_allowed(&bob, &resource).unwrap()); // no associations → denied
 
-    // member of an associated ring is allowed
     reg.add_peer_to_ring("friends", bob, None).unwrap();
     reg.add_ring_to_resource(resource, "friends").unwrap();
-    assert!(reg.is_allowed(&bob, &resource).unwrap());
+    assert!(reg.is_allowed(&bob, &resource).unwrap()); // ring member allowed
 
-    // non-member is denied
     let stranger = make_peer();
-    assert!(!reg.is_allowed(&stranger, &resource).unwrap());
+    assert!(!reg.is_allowed(&stranger, &resource).unwrap()); // non-member denied
 
-    // open ring allows everyone
     reg.add_ring_to_resource(resource, OPEN_RING_NAME).unwrap();
-    assert!(reg.is_allowed(&stranger, &resource).unwrap());
+    assert!(reg.is_allowed(&stranger, &resource).unwrap()); // open ring allows anyone
 
-    // remove_ring_from_resource clears all access
+    let resource_multi = make_resource(0x01);
+    let peer_work = make_peer();
+    reg.add_ring_to_resource(resource_multi, "friends").unwrap();
+    reg.add_ring_to_resource(resource_multi, "work").unwrap();
+    reg.add_peer_to_ring("work", peer_work, None).unwrap();
+    assert!(reg.is_allowed(&peer_work, &resource_multi).unwrap()); // member of any associated ring
+
     reg.remove_ring_from_resource(resource).unwrap();
     assert_eq!(reg.list_resource_rings(resource).unwrap().len(), 0);
     assert!(!reg.is_allowed(&stranger, &resource).unwrap());
+
+    // --- resource–ring association semantics ---
+
+    assert_eq!(
+        reg.list_resource_rings(make_resource(0xfe)).unwrap(),
+        vec![]
+    );
+    assert!(reg
+        .add_ring_to_resource(make_resource(0xfd), "ghost")
+        .is_err());
+
+    // open ring clears all private rings
+    let res_a = make_resource(0x02);
+    reg.create_ring("ring_a").unwrap();
+    reg.add_ring_to_resource(res_a, "ring_a").unwrap();
+    reg.add_ring_to_resource(res_a, OPEN_RING_NAME).unwrap();
+    assert_eq!(
+        reg.list_resource_rings(res_a).unwrap(),
+        vec![Ring::new_open()]
+    );
+
+    // private ring clears the open ring
+    let res_b = make_resource(0x03);
+    reg.create_ring("ring_b").unwrap();
+    reg.add_ring_to_resource(res_b, OPEN_RING_NAME).unwrap();
+    reg.add_ring_to_resource(res_b, "ring_b").unwrap();
+    assert_eq!(
+        reg.list_resource_rings(res_b).unwrap(),
+        vec![Ring::new("ring_b").unwrap()]
+    );
+
+    // associating the same ring twice is idempotent
+    let res_c = make_resource(0x04);
+    reg.create_ring("ring_c").unwrap();
+    reg.add_ring_to_resource(res_c, "ring_c").unwrap();
+    reg.add_ring_to_resource(res_c, "ring_c").unwrap();
+    assert_eq!(reg.list_resource_rings(res_c).unwrap().len(), 1);
+
+    // multiple private rings accumulate
+    let res_d = make_resource(0x05);
+    reg.create_ring("ring_d").unwrap();
+    reg.create_ring("ring_e").unwrap();
+    reg.add_ring_to_resource(res_d, "ring_d").unwrap();
+    reg.add_ring_to_resource(res_d, "ring_e").unwrap();
+    let rings = reg.list_resource_rings(res_d).unwrap();
+    assert_eq!(rings.len(), 2);
+    assert!(rings.contains(&Ring::new("ring_d").unwrap()));
+    assert!(rings.contains(&Ring::new("ring_e").unwrap()));
+
+    // --- nicknames ---
+
+    let nick_peer = make_peer();
+    let no_nick_peer = make_peer();
+    reg.create_ring("nick_ring").unwrap();
+
+    reg.add_peer_to_ring("nick_ring", nick_peer, Some("alice"))
+        .unwrap();
+    let members = reg.list_ring_peers("nick_ring").unwrap();
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].1.as_deref(), Some("alice"));
+
+    reg.add_peer_to_ring("nick_ring", no_nick_peer, None)
+        .unwrap();
+    let found = reg.list_ring_peers("nick_ring").unwrap();
+    assert_eq!(
+        found.iter().find(|(p, _)| p == &no_nick_peer).unwrap().1,
+        None
+    );
+
+    reg.add_peer_to_ring("nick_ring", nick_peer, Some("alice2"))
+        .unwrap(); // update nickname
+    let members = reg.list_ring_peers("nick_ring").unwrap();
+    assert_eq!(members.len(), 2);
+    assert_eq!(
+        members
+            .iter()
+            .find(|(p, _)| p == &nick_peer)
+            .unwrap()
+            .1
+            .as_deref(),
+        Some("alice2")
+    );
+
+    reg.remove_peer_from_ring("nick_ring", nick_peer).unwrap();
+    reg.add_peer_to_ring("nick_ring", nick_peer, None).unwrap(); // nickname cleared on removal
+    let found = reg.list_ring_peers("nick_ring").unwrap();
+    assert_eq!(found.iter().find(|(p, _)| p == &nick_peer).unwrap().1, None);
+
+    // same peer can have different nicknames in different rings
+    let cross_peer = make_peer();
+    reg.create_ring("nick_ring2").unwrap();
+    reg.add_peer_to_ring("nick_ring", cross_peer, Some("name_a"))
+        .unwrap();
+    reg.add_peer_to_ring("nick_ring2", cross_peer, Some("name_b"))
+        .unwrap();
+    let r1 = reg.list_ring_peers("nick_ring").unwrap();
+    let r2 = reg.list_ring_peers("nick_ring2").unwrap();
+    assert_eq!(
+        r1.iter()
+            .find(|(p, _)| p == &cross_peer)
+            .unwrap()
+            .1
+            .as_deref(),
+        Some("name_a")
+    );
+    assert_eq!(
+        r2.iter()
+            .find(|(p, _)| p == &cross_peer)
+            .unwrap()
+            .1
+            .as_deref(),
+        Some("name_b")
+    );
+
+    // members with and without nicknames coexist in the same ring
+    let nicks: Vec<_> = reg
+        .list_ring_peers("nick_ring")
+        .unwrap()
+        .into_iter()
+        .map(|(_, n)| n)
+        .collect();
+    assert!(nicks.iter().any(|n| n.as_deref() == Some("name_a")));
+    assert!(nicks.iter().any(|n| n.is_none()));
 }

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,6 +1,7 @@
-use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
+
+use crate::Error;
 
 /// Reserved name for the built-in open ring (the public ring):
 /// resources associated with this ring are accessible to any peer without membership checks.
@@ -21,15 +22,13 @@ pub struct Ring {
 }
 
 impl Ring {
-    pub fn new<S: AsRef<str>>(name: S) -> Result<Self> {
+    pub fn new<S: AsRef<str>>(name: S) -> Result<Self, Error> {
         let name = name.as_ref();
         if name.is_empty() {
-            return Err(anyhow!("ring name must not be empty"));
+            return Err(Error::RingNameEmpty);
         }
         if name.contains(|c: char| c.is_whitespace() || c == '\0') {
-            return Err(anyhow!(
-                "ring name must not contain whitespace or NUL bytes"
-            ));
+            return Err(Error::RingNameInvalidChars);
         }
         Ok(Self {
             name: name.to_string(),

--- a/src/transfers/fs.rs
+++ b/src/transfers/fs.rs
@@ -192,6 +192,13 @@ mod tests {
     use super::*;
     use bao_tree::ChunkNum;
 
+    fn assert_ranges_roundtrip(ranges: bao_tree::ChunkRanges) {
+        let encoded = encode_ranges_wire(&ranges);
+        let count = u32::from_le_bytes(encoded[..4].try_into().unwrap());
+        let decoded = decode_ranges_wire(count, &encoded[4..]).unwrap();
+        assert_eq!(decoded, ranges);
+    }
+
     #[test]
     fn encode_decode_empty_ranges() {
         let ranges = bao_tree::ChunkRanges::empty();
@@ -203,22 +210,14 @@ mod tests {
 
     #[test]
     fn encode_decode_single_range() {
-        let ranges = bao_tree::ChunkRanges::from(ChunkNum(0)..ChunkNum(10));
-        let encoded = encode_ranges_wire(&ranges);
-        let count = u32::from_le_bytes(encoded[..4].try_into().unwrap());
-        let decoded = decode_ranges_wire(count, &encoded[4..]).unwrap();
-        assert_eq!(decoded, ranges);
+        assert_ranges_roundtrip(bao_tree::ChunkRanges::from(ChunkNum(0)..ChunkNum(10)));
     }
 
     #[test]
     fn encode_decode_multiple_ranges() {
         let r1 = bao_tree::ChunkRanges::from(ChunkNum(0)..ChunkNum(4));
         let r2 = bao_tree::ChunkRanges::from(ChunkNum(10)..ChunkNum(20));
-        let ranges = r1 | r2;
-        let encoded = encode_ranges_wire(&ranges);
-        let count = u32::from_le_bytes(encoded[..4].try_into().unwrap());
-        let decoded = decode_ranges_wire(count, &encoded[4..]).unwrap();
-        assert_eq!(decoded, ranges);
+        assert_ranges_roundtrip(r1 | r2);
     }
 
     #[test]


### PR DESCRIPTION
Closes #10

Introduce `crate::Error` (thiserror-backed enum) so callers can match on specific failure modes instead of receiving an opaque `anyhow::Error`.
