### PR TITLE
refactor(protocol)reexport ALPN name according to iroh ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ NULL-free. The reserved name `"open"` is the open ring.
 The `Registry` trait manages rings and resource-ring associations:
 
 ```rust
+use iroh_rings::InMemoryRegistry;
+
 let reg = InMemoryRegistry::new(); // or RedbRegistry::open("rings.db")?
 reg.create_ring("friends")?;
 reg.add_peer_to_ring("friends", peer_id, Some("alice"))?;
@@ -75,12 +77,14 @@ Gate -> initiator  [ 1 B]  0x00 = DENIED  /  0x01 = ALLOWED
                    [rest]  sub-protocol defined by the Transfer implementor
 ```
 
-Wire the gate into an iroh `Router` using the provided `SC_ALPN` (`b"/iroh-rings/1"`):
+Wire the gate into an iroh `Router` using the provided `ALPN` (`b"/iroh-rings/1"`):
 
 ```rust
+use iroh_rings::{ALPN, RingGate};
+
 let gate = RingGate::new(registry, transfer);
 let router = Router::builder(endpoint) // endpoint: iroh::Endpoint
-    .accept(SC_ALPN, gate)
+    .accept(ALPN, gate)
     .spawn();
 ```
 
@@ -90,6 +94,10 @@ let router = Router::builder(endpoint) // endpoint: iroh::Endpoint
 Implement it to build your own sub-protocol:
 
 ```rust
+use iroh::endpoint::{RecvStream, SendStream};
+use iroh::EndpointId;
+use iroh_rings::Transfer;
+
 impl Transfer for MyTransfer {
     async fn can_access(&self, peer: &EndpointId, resource_id: &[u8]) -> bool {
         // secondary access check (e.g. collection membership)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod transfers;
 mod ring;
 
 pub use error::Error;
+pub use protocol::{RingGate, Transfer, RINGS_ALPN as ALPN};
 pub use registry::{Registry, ResourceId};
 pub use ring::{Ring, OPEN_RING_NAME};
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -19,7 +19,7 @@ mod gate;
 pub use gate::{RingGate, Transfer};
 
 /// ALPN identifier used to negotiate the iroh-rings protocol during the QUIC handshake.
-pub const SC_ALPN: &[u8] = b"/iroh-rings/1";
+pub const RINGS_ALPN: &[u8] = b"/iroh-rings/1";
 
 /// Maximum number of bytes accepted for a resource id on the wire.
 ///
@@ -62,6 +62,15 @@ impl TryFrom<u8> for Status {
             0x00 => Ok(Status::Denied),
             0x01 => Ok(Status::Allowed),
             _ => Err(crate::Error::UnknownStatusByte(b)),
+        }
+    }
+}
+
+impl std::fmt::Display for Status {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Status::Denied => f.write_str("Denied"),
+            Status::Allowed => f.write_str("Allowed"),
         }
     }
 }

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -43,6 +43,7 @@ impl Ring {
     }
 
     /// Creates the built-in open ring.
+    #[must_use]
     pub fn new_open() -> Self {
         Self {
             name: OPEN_RING_NAME.to_string(),
@@ -51,16 +52,19 @@ impl Ring {
     }
 
     /// Returns the ring name as a string slice.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.name
     }
 
     /// Returns `true` if this is the built-in open ring.
+    #[must_use]
     pub fn is_open(&self) -> bool {
         self.name == OPEN_RING_NAME
     }
 
     /// Returns the creation timestamp, used for display ordering only.
+    #[must_use]
     pub fn timestamp(&self) -> Instant {
         self.timestamp
     }


### PR DESCRIPTION
Closes #14

Also added some other useful public reexports (`RingGate`, `Transfer`) and added `Display` trait implementation for the `Status` struct.