### PR TITLE
Extend Read permission access model with Write, Delete

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,9 @@ iroh-io = { version = "0.6", optional = true }
 bytes = { version = "1", optional = true }
 futures-lite = { version = "2", optional = true }
 
+[[example]]
+name = "access_control"
+required-features = ["mem"]
+
 [dev-dependencies]
 tempfile = "3"

--- a/examples/access_control.rs
+++ b/examples/access_control.rs
@@ -1,0 +1,136 @@
+//! End-to-end example: one server, one authorized member, one stranger.
+//!
+//! Run with:
+//!   cargo run --example access_control --features mem
+//!
+//! What this shows:
+//!   1. A server creates a ring, associates a resource with Read permission, and
+//!      starts a [`RingGate`]-protected endpoint.
+//!   2. A "member" peer that was added to the ring connects, requests the resource,
+//!      and receives the payload.
+//!   3. A "stranger" peer that was never added to the ring connects, requests the
+//!      same resource, and is denied — no payload is sent.
+
+use anyhow::Result;
+use std::collections::BTreeSet;
+
+use iroh::{
+    endpoint::{presets, Connection, RecvStream, SendStream},
+    protocol::Router,
+    Endpoint, EndpointAddr, EndpointId, SecretKey, TransportAddr,
+};
+use iroh_rings::{
+    protocol::{encode_request, Status},
+    InMemoryRegistry, Permission, Registry, RingGate, ALPN,
+};
+
+// The resource identifier — any stable byte sequence up to 256 bytes.
+const RESOURCE_ID: &[u8] = b"example-document-v1";
+
+// The payload the server sends when access is granted.
+const CONTENT: &[u8] = b"the content of example-document-v1";
+
+/// A minimal [`iroh_rings::Transfer`] that serves a fixed in-memory payload.
+///
+/// Real implementations would look up `resource_id` in a local store and
+/// stream the corresponding data over `send`.
+#[derive(Clone)]
+struct StaticTransfer;
+
+impl iroh_rings::Transfer for StaticTransfer {
+    async fn can_access(&self, _peer: &EndpointId, _resource_id: &[u8]) -> bool {
+        true // rely entirely on ring membership; no additional check needed here
+    }
+
+    async fn transfer(
+        &self,
+        _resource_id: &[u8],
+        send: &mut SendStream,
+        _recv: &mut RecvStream,
+    ) -> Result<()> {
+        send.write_all(CONTENT).await?;
+        Ok(())
+    }
+}
+
+/// Connects to `server_addr`, requests `RESOURCE_ID` with `Read` permission,
+/// and returns the payload if access was granted or `None` if denied.
+async fn fetch(endpoint: &Endpoint, server_addr: EndpointAddr) -> Result<Option<Vec<u8>>> {
+    let conn: Connection = endpoint.connect(server_addr, ALPN).await?;
+    let (mut send, mut recv): (SendStream, RecvStream) = conn.open_bi().await?;
+
+    send.write_all(&encode_request(RESOURCE_ID, Permission::Read)?)
+        .await?;
+    send.finish()?;
+
+    let mut status_buf = [0u8; 1];
+    recv.read_exact(&mut status_buf).await?;
+
+    match Status::try_from(status_buf[0])? {
+        Status::Allowed => {
+            let data = recv.read_to_end(64 * 1024).await?;
+            Ok(Some(data))
+        }
+        Status::Denied => Ok(None),
+        _ => anyhow::bail!("unexpected status byte: {}", status_buf[0]),
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Generate member key upfront so we can register it before it connects.
+    let member_key = SecretKey::generate();
+    let member_id: EndpointId = member_key.public();
+
+    // Server setup
+
+    let registry = InMemoryRegistry::new();
+
+    registry.create_ring("readers")?;
+    registry.add_ring_to_resource(RESOURCE_ID.to_vec(), "readers", &[Permission::Read])?;
+    registry.add_peer_to_ring("readers", member_id, Some("alice"))?;
+
+    let server = Endpoint::builder(presets::Minimal).bind().await?;
+    let gate = RingGate::new(registry, StaticTransfer);
+    let _router = Router::builder(server.clone()).accept(ALPN, gate).spawn();
+
+    // Build the server's EndpointAddr from its bound local sockets so the
+    // clients can reach it directly without a relay.
+    let server_addr = EndpointAddr {
+        id: server.id(),
+        addrs: server
+            .bound_sockets()
+            .into_iter()
+            .map(TransportAddr::Ip)
+            .collect::<BTreeSet<_>>(),
+    };
+
+    println!("server : {}", server.id());
+    println!("resource: {}", String::from_utf8_lossy(RESOURCE_ID));
+    println!();
+
+    // Authorized member
+
+    let member = Endpoint::builder(presets::Minimal)
+        .secret_key(member_key)
+        .bind()
+        .await?;
+
+    print!("member  (in ring)  … ");
+    match fetch(&member, server_addr.clone()).await? {
+        Some(data) => println!("ALLOWED — payload: {:?}", String::from_utf8_lossy(&data)),
+        None => println!("DENIED (unexpected)"),
+    }
+
+    // Stranger (not in the ring)
+
+    let stranger = Endpoint::builder(presets::Minimal).bind().await?;
+
+    print!("stranger (no ring) … ");
+    match fetch(&stranger, server_addr).await? {
+        Some(_) => println!("ALLOWED (unexpected)"),
+        None => println!("DENIED (expected)"),
+    }
+
+    Ok(())
+}

--- a/src/backends/memory.rs
+++ b/src/backends/memory.rs
@@ -169,6 +169,10 @@ impl Registry for InMemoryRegistry {
         if permissions.is_empty() {
             return Err(Error::EmptyPermissionSet);
         }
+        if ring_name == OPEN_RING_NAME && permissions.iter().any(|p| !matches!(p, Permission::Read))
+        {
+            return Err(Error::OpenRingReadOnly);
+        }
         let mut inner = self.inner.write().unwrap();
         if !inner.rings.contains_key(ring_name) {
             return Err(Error::RingNotFound(ring_name.to_string()));

--- a/src/backends/memory.rs
+++ b/src/backends/memory.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, RwLock};
 
 use iroh::EndpointId;
 
-use crate::registry::{Registry, ResourceId};
+use crate::registry::{Permission, Registry, ResourceId};
 use crate::ring::{Ring, OPEN_RING_NAME};
 use crate::Error;
 
@@ -18,7 +18,8 @@ use crate::Error;
 struct Inner {
     rings: HashMap<String, Vec<[u8; 32]>>,
     nicknames: HashMap<(String, [u8; 32]), String>,
-    resource_rings: HashMap<Vec<u8>, Vec<String>>,
+    /// Maps resource id → ordered list of (ring_name, permissions) pairs.
+    resource_rings: HashMap<Vec<u8>, Vec<(String, Vec<Permission>)>>,
 }
 
 /// Thread-safe, non-persistent registry backed by in-memory hash maps;
@@ -140,15 +141,20 @@ impl Registry for InMemoryRegistry {
     fn list_resource_rings<ResId: ResourceId>(
         &self,
         resource_id: ResId,
-    ) -> Result<Vec<Ring>, Error> {
+    ) -> Result<Vec<(Ring, Vec<Permission>)>, Error> {
         let inner = self.inner.read().unwrap();
         Ok(inner
             .resource_rings
             .get(resource_id.as_bytes())
-            .map(|names| {
-                names
+            .map(|entries| {
+                entries
                     .iter()
-                    .map(|n| Ring::new(n).expect("invariant: ring names are always valid"))
+                    .map(|(n, p)| {
+                        (
+                            Ring::new(n).expect("invariant: ring names are always valid"),
+                            p.clone(),
+                        )
+                    })
                     .collect()
             })
             .unwrap_or_default())
@@ -158,36 +164,45 @@ impl Registry for InMemoryRegistry {
         &self,
         resource_id: ResId,
         ring_name: &str,
+        permissions: &[Permission],
     ) -> Result<(), Error> {
+        if permissions.is_empty() {
+            return Err(Error::EmptyPermissionSet);
+        }
         let mut inner = self.inner.write().unwrap();
         if !inner.rings.contains_key(ring_name) {
             return Err(Error::RingNotFound(ring_name.to_string()));
         }
         let key = resource_id.as_bytes().to_vec();
         let existing = inner.resource_rings.get(&key).cloned().unwrap_or_default();
-        let names = crate::registry::compute_resource_rings(existing, ring_name);
-        inner.resource_rings.insert(key, names);
+        let updated =
+            crate::registry::compute_resource_rings(existing, ring_name, permissions.to_vec());
+        inner.resource_rings.insert(key, updated);
         Ok(())
     }
 
-    fn is_allowed<ResId: ResourceId>(
+    fn has_permission<ResId: ResourceId>(
         &self,
         peer: &EndpointId,
         resource_id: &ResId,
+        permission: Permission,
     ) -> Result<bool, Error> {
         let inner = self.inner.read().unwrap();
-        let ring_names = match inner.resource_rings.get(resource_id.as_bytes()) {
+        let entries = match inner.resource_rings.get(resource_id.as_bytes()) {
             None => return Ok(false),
-            Some(names) => names,
+            Some(e) => e,
         };
-        if ring_names.is_empty() {
+        if entries.is_empty() {
             return Ok(false);
         }
-        if ring_names.iter().any(|n| n == OPEN_RING_NAME) {
-            return Ok(true);
-        }
         let peer_bytes = *peer.as_bytes();
-        for name in ring_names {
+        for (name, perms) in entries {
+            if !perms.contains(&permission) {
+                continue;
+            }
+            if name == OPEN_RING_NAME {
+                return Ok(true);
+            }
             if let Some(members) = inner.rings.get(name.as_str()) {
                 if members.contains(&peer_bytes) {
                     return Ok(true);

--- a/src/backends/memory.rs
+++ b/src/backends/memory.rs
@@ -166,13 +166,7 @@ impl Registry for InMemoryRegistry {
         ring_name: &str,
         permissions: &[Permission],
     ) -> Result<(), Error> {
-        if permissions.is_empty() {
-            return Err(Error::EmptyPermissionSet);
-        }
-        if ring_name == OPEN_RING_NAME && permissions.iter().any(|p| !matches!(p, Permission::Read))
-        {
-            return Err(Error::OpenRingReadOnly);
-        }
+        crate::registry::validate_ring_permissions(ring_name, permissions)?;
         let mut inner = self.inner.write().unwrap();
         if !inner.rings.contains_key(ring_name) {
             return Err(Error::RingNotFound(ring_name.to_string()));

--- a/src/backends/redb.rs
+++ b/src/backends/redb.rs
@@ -240,6 +240,10 @@ impl Registry for RedbRegistry {
         if permissions.is_empty() {
             return Err(Error::EmptyPermissionSet);
         }
+        if ring_name == OPEN_RING_NAME && permissions.iter().any(|p| !matches!(p, Permission::Read))
+        {
+            return Err(Error::OpenRingReadOnly);
+        }
         let write = self.db.begin_write().map_err(storage)?;
         {
             let rings_table = write.open_table(RINGS).map_err(storage)?;

--- a/src/backends/redb.rs
+++ b/src/backends/redb.rs
@@ -22,7 +22,7 @@ use std::{path::Path, sync::Arc};
 use iroh::EndpointId;
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 
-use crate::registry::{Registry, ResourceId};
+use crate::registry::{Permission, Registry, ResourceId};
 use crate::ring::{Ring, OPEN_RING_NAME};
 use crate::Error;
 
@@ -40,6 +40,12 @@ const RESOURCE_RINGS: TableDefinition<&[u8], &[u8]> = TableDefinition::new("reso
 /// Maps `ring_name \0 peer_id_bytes` to nickname string (display label only).
 /// Ring names are validated to contain no NUL, so the separator is unambiguous.
 const NICKNAMES: TableDefinition<&[u8], &str> = TableDefinition::new("nicknames");
+
+/// Maps a composite key `[2B resource_id_len_le][resource_id][ring_name]` to a
+/// permission bitfield (`u8`): bit 0 = Read, bit 1 = Write, bit 2 = Delete.
+///
+/// The 2-byte length prefix makes the key unambiguous for arbitrary resource id bytes.
+const RESOURCE_RING_PERMS: TableDefinition<&[u8], u8> = TableDefinition::new("resource_ring_perms");
 
 /// Persistent registry, cheaply cloneable via Arc.
 #[derive(Clone)]
@@ -62,6 +68,7 @@ impl RedbRegistry {
             let mut rings = write.open_table(RINGS).map_err(storage)?;
             write.open_table(RESOURCE_RINGS).map_err(storage)?;
             write.open_table(NICKNAMES).map_err(storage)?;
+            write.open_table(RESOURCE_RING_PERMS).map_err(storage)?;
 
             if rings.get(OPEN_RING_NAME).map_err(storage)?.is_none() {
                 rings
@@ -201,17 +208,26 @@ impl Registry for RedbRegistry {
     fn list_resource_rings<ResId: ResourceId>(
         &self,
         resource_id: ResId,
-    ) -> Result<Vec<Ring>, Error> {
+    ) -> Result<Vec<(Ring, Vec<Permission>)>, Error> {
         let read = self.db.begin_read().map_err(storage)?;
-        let table = read.open_table(RESOURCE_RINGS).map_err(storage)?;
-        match table.get(resource_id.as_bytes()).map_err(storage)? {
+        let rr_table = read.open_table(RESOURCE_RINGS).map_err(storage)?;
+        let perm_table = read.open_table(RESOURCE_RING_PERMS).map_err(storage)?;
+        match rr_table.get(resource_id.as_bytes()).map_err(storage)? {
             None => Ok(Vec::new()),
-            Some(v) => Ok(decode_ring_names(v.value())
+            Some(v) => decode_ring_names(v.value())
                 .into_iter()
                 .map(|ring_name| {
-                    Ring::new(ring_name).expect("invariant: db ring names are always valid")
+                    let ring =
+                        Ring::new(&ring_name).expect("invariant: db ring names are always valid");
+                    let key = perm_key(resource_id.as_bytes(), &ring_name);
+                    let perms = perm_table
+                        .get(key.as_slice())
+                        .map_err(storage)?
+                        .map(|v| byte_to_perms(v.value()))
+                        .unwrap_or_default();
+                    Ok((ring, perms))
                 })
-                .collect()),
+                .collect(),
         }
     }
 
@@ -219,56 +235,92 @@ impl Registry for RedbRegistry {
         &self,
         resource_id: ResId,
         ring_name: &str,
+        permissions: &[Permission],
     ) -> Result<(), Error> {
+        if permissions.is_empty() {
+            return Err(Error::EmptyPermissionSet);
+        }
         let write = self.db.begin_write().map_err(storage)?;
         {
             let rings_table = write.open_table(RINGS).map_err(storage)?;
             if rings_table.get(ring_name).map_err(storage)?.is_none() {
                 return Err(Error::RingNotFound(ring_name.to_string()));
             }
-            drop(rings_table); // redb only allows one open at a time
+            drop(rings_table); // redb only allows one mutable table open at a time
 
-            let mut table = write.open_table(RESOURCE_RINGS).map_err(storage)?;
+            let mut rr_table = write.open_table(RESOURCE_RINGS).map_err(storage)?;
             let key = resource_id.as_bytes();
-            let existing = match table.get(key).map_err(storage)? {
-                Some(v) => decode_ring_names(v.value()),
+            let existing = match rr_table.get(key).map_err(storage)? {
+                Some(v) => decode_ring_names(v.value())
+                    .into_iter()
+                    .map(|n| (n, vec![]))
+                    .collect(),
                 None => Vec::new(),
             };
-
-            let names = crate::registry::compute_resource_rings(existing, ring_name);
-            table
-                .insert(key, encode_ring_names(&names).as_slice())
+            let updated =
+                crate::registry::compute_resource_rings(existing, ring_name, permissions.to_vec());
+            rr_table
+                .insert(
+                    key,
+                    encode_ring_names(&updated.iter().map(|(n, _)| n.clone()).collect::<Vec<_>>())
+                        .as_slice(),
+                )
                 .map_err(storage)?;
+            drop(rr_table);
+
+            let mut perm_table = write.open_table(RESOURCE_RING_PERMS).map_err(storage)?;
+            // Remove permissions for rings that were displaced (e.g. open ring cleared by private)
+            // by re-writing only the rings present in `updated`.
+            for (name, perms) in &updated {
+                let k = perm_key(resource_id.as_bytes(), name);
+                perm_table
+                    .insert(k.as_slice(), perms_to_byte(perms))
+                    .map_err(storage)?;
+            }
         }
         write.commit().map_err(storage)?;
         Ok(())
     }
 
-    fn is_allowed<ResId: ResourceId>(
+    fn has_permission<ResId: ResourceId>(
         &self,
         peer: &EndpointId,
         resource_id: &ResId,
+        permission: Permission,
     ) -> Result<bool, Error> {
         let read = self.db.begin_read().map_err(storage)?;
 
-        let fr_table = read.open_table(RESOURCE_RINGS).map_err(storage)?;
-        let ring_names = match fr_table.get(resource_id.as_bytes()).map_err(storage)? {
+        let rr_table = read.open_table(RESOURCE_RINGS).map_err(storage)?;
+        let ring_names = match rr_table.get(resource_id.as_bytes()).map_err(storage)? {
             None => return Ok(false),
             Some(v) => decode_ring_names(v.value()),
         };
         if ring_names.is_empty() {
             return Ok(false);
         }
-        if ring_names.iter().any(|n| n == OPEN_RING_NAME) {
-            return Ok(true);
-        }
 
+        let perm_table = read.open_table(RESOURCE_RING_PERMS).map_err(storage)?;
         let r_table = read.open_table(RINGS).map_err(storage)?;
         let peer_bytes = *peer.as_bytes();
+
         for name in &ring_names {
+            let k = perm_key(resource_id.as_bytes(), name);
+            let perms = perm_table
+                .get(k.as_slice())
+                .map_err(storage)?
+                .map(|v| byte_to_perms(v.value()))
+                .unwrap_or_default();
+            if !perms.contains(&permission) {
+                continue;
+            }
+            if name == OPEN_RING_NAME {
+                return Ok(true);
+            }
             if let Some(members_raw) = r_table.get(name.as_str()).map_err(storage)? {
-                let members = decode_peer_ids(members_raw.value());
-                if members.iter().any(|b| b == &peer_bytes) {
+                if decode_peer_ids(members_raw.value())
+                    .iter()
+                    .any(|b| b == &peer_bytes)
+                {
                     return Ok(true);
                 }
             }
@@ -299,6 +351,47 @@ fn decode_peer_ids(raw: &[u8]) -> Vec<[u8; 32]> {
                 .expect("invariant: chunks_exact(32) yields 32-byte slices")
         })
         .collect()
+}
+
+/// Composite key for the `RESOURCE_RING_PERMS` table.
+///
+/// Uses a 2-byte little-endian length prefix so the boundary between the
+/// resource id bytes and the ring name bytes is always unambiguous, regardless
+/// of the resource id content.
+fn perm_key(resource_id: &[u8], ring_name: &str) -> Vec<u8> {
+    let len = resource_id.len() as u16;
+    let mut key = Vec::with_capacity(2 + resource_id.len() + ring_name.len());
+    key.extend_from_slice(&len.to_le_bytes());
+    key.extend_from_slice(resource_id);
+    key.extend_from_slice(ring_name.as_bytes());
+    key
+}
+
+fn perms_to_byte(perms: &[Permission]) -> u8 {
+    let mut bits = 0u8;
+    for p in perms {
+        match p {
+            Permission::Read => bits |= 0b001,
+            Permission::Write => bits |= 0b010,
+            Permission::Delete => bits |= 0b100,
+            _ => {}
+        }
+    }
+    bits
+}
+
+fn byte_to_perms(bits: u8) -> Vec<Permission> {
+    let mut perms = Vec::new();
+    if bits & 0b001 != 0 {
+        perms.push(Permission::Read);
+    }
+    if bits & 0b010 != 0 {
+        perms.push(Permission::Write);
+    }
+    if bits & 0b100 != 0 {
+        perms.push(Permission::Delete);
+    }
+    perms
 }
 
 fn encode_ring_names(names: &[String]) -> Vec<u8> {

--- a/src/backends/redb.rs
+++ b/src/backends/redb.rs
@@ -202,8 +202,23 @@ impl Registry for RedbRegistry {
     ) -> Result<(), Error> {
         let write = self.db.begin_write().map_err(storage)?;
         {
+            let key = resource_id.as_bytes();
             let mut table = write.open_table(RESOURCE_RINGS).map_err(storage)?;
-            table.remove(resource_id.as_bytes()).map_err(storage)?;
+            let ring_names = table
+                .remove(key)
+                .map_err(storage)?
+                .map(|v| decode_ring_names(v.value()))
+                .unwrap_or_default();
+            drop(table);
+
+            if !ring_names.is_empty() {
+                let mut perm_table = write.open_table(RESOURCE_RING_PERMS).map_err(storage)?;
+                for name in &ring_names {
+                    perm_table
+                        .remove(perm_key(key, name).as_slice())
+                        .map_err(storage)?;
+                }
+            }
         }
         write.commit().map_err(storage)?;
         Ok(())
@@ -241,13 +256,7 @@ impl Registry for RedbRegistry {
         ring_name: &str,
         permissions: &[Permission],
     ) -> Result<(), Error> {
-        if permissions.is_empty() {
-            return Err(Error::EmptyPermissionSet);
-        }
-        if ring_name == OPEN_RING_NAME && permissions.iter().any(|p| !matches!(p, Permission::Read))
-        {
-            return Err(Error::OpenRingReadOnly);
-        }
+        crate::registry::validate_ring_permissions(ring_name, permissions)?;
         let write = self.db.begin_write().map_err(storage)?;
         {
             let rings_table = write.open_table(RINGS).map_err(storage)?;
@@ -256,35 +265,57 @@ impl Registry for RedbRegistry {
             }
             drop(rings_table); // redb only allows one mutable table open at a time
 
-            let mut rr_table = write.open_table(RESOURCE_RINGS).map_err(storage)?;
             let key = resource_id.as_bytes();
-            let existing = match rr_table.get(key).map_err(storage)? {
-                Some(v) => decode_ring_names(v.value())
-                    .into_iter()
-                    .map(|n| (n, vec![]))
-                    .collect(),
-                None => Vec::new(),
+
+            // Read existing ring names from RESOURCE_RINGS.
+            let rr_table = write.open_table(RESOURCE_RINGS).map_err(storage)?;
+            let ring_names = match rr_table.get(key).map_err(storage)? {
+                Some(v) => decode_ring_names(v.value()),
+                None => vec![],
             };
+            drop(rr_table);
+
+            // Look up stored permissions for each existing ring (preserves their permissions).
+            let existing: Vec<(String, Vec<Permission>)> = if ring_names.is_empty() {
+                vec![]
+            } else {
+                let perm_table = write.open_table(RESOURCE_RING_PERMS).map_err(storage)?;
+                let result = ring_names
+                    .into_iter()
+                    .map(|n| {
+                        let k = perm_key(key, &n);
+                        let perms = perm_table
+                            .get(k.as_slice())
+                            .map_err(storage)?
+                            .map(|v| byte_to_perms(v.value()))
+                            .unwrap_or_default();
+                        Ok((n, perms))
+                    })
+                    .collect::<Result<Vec<_>, Error>>();
+                drop(perm_table);
+                result?
+            };
+
             let updated =
                 crate::registry::compute_resource_rings(existing, ring_name, permissions.to_vec());
+
+            let mut rr_table = write.open_table(RESOURCE_RINGS).map_err(storage)?;
             rr_table
                 .insert(
                     key,
-                    encode_ring_names(&updated.iter().map(|(n, _)| n.clone()).collect::<Vec<_>>())
-                        .as_slice(),
+                    encode_ring_names(updated.iter().map(|(n, _)| n.as_str())).as_slice(),
                 )
                 .map_err(storage)?;
             drop(rr_table);
 
+            // Only write the new ring's permission row; existing rings' rows are already correct.
             let mut perm_table = write.open_table(RESOURCE_RING_PERMS).map_err(storage)?;
-            // Remove permissions for rings that were displaced (e.g. open ring cleared by private)
-            // by re-writing only the rings present in `updated`.
-            for (name, perms) in &updated {
-                let k = perm_key(resource_id.as_bytes(), name);
-                perm_table
-                    .insert(k.as_slice(), perms_to_byte(perms))
-                    .map_err(storage)?;
-            }
+            perm_table
+                .insert(
+                    perm_key(key, ring_name).as_slice(),
+                    perms_to_byte(permissions),
+                )
+                .map_err(storage)?;
         }
         write.commit().map_err(storage)?;
         Ok(())
@@ -310,24 +341,26 @@ impl Registry for RedbRegistry {
         let perm_table = read.open_table(RESOURCE_RING_PERMS).map_err(storage)?;
         let r_table = read.open_table(RINGS).map_err(storage)?;
         let peer_bytes = *peer.as_bytes();
+        let pbit = permission_bit(permission);
 
         for name in &ring_names {
             let k = perm_key(resource_id.as_bytes(), name);
-            let perms = perm_table
+            let bits = perm_table
                 .get(k.as_slice())
                 .map_err(storage)?
-                .map(|v| byte_to_perms(v.value()))
-                .unwrap_or_default();
-            if !perms.contains(&permission) {
+                .map(|v| v.value())
+                .unwrap_or(0);
+            if bits & pbit == 0 {
                 continue;
             }
             if name == OPEN_RING_NAME {
                 return Ok(true);
             }
             if let Some(members_raw) = r_table.get(name.as_str()).map_err(storage)? {
-                if decode_peer_ids(members_raw.value())
-                    .iter()
-                    .any(|b| b == &peer_bytes)
+                if members_raw
+                    .value()
+                    .chunks_exact(32)
+                    .any(|b| b == peer_bytes.as_slice())
                 {
                     return Ok(true);
                 }
@@ -375,17 +408,16 @@ fn perm_key(resource_id: &[u8], ring_name: &str) -> Vec<u8> {
     key
 }
 
-fn perms_to_byte(perms: &[Permission]) -> u8 {
-    let mut bits = 0u8;
-    for p in perms {
-        match p {
-            Permission::Read => bits |= 0b001,
-            Permission::Write => bits |= 0b010,
-            Permission::Delete => bits |= 0b100,
-            _ => {}
-        }
+fn permission_bit(p: Permission) -> u8 {
+    match p {
+        Permission::Read => 0b001,
+        Permission::Write => 0b010,
+        Permission::Delete => 0b100,
     }
-    bits
+}
+
+fn perms_to_byte(perms: &[Permission]) -> u8 {
+    perms.iter().fold(0u8, |bits, &p| bits | permission_bit(p))
 }
 
 fn byte_to_perms(bits: u8) -> Vec<Permission> {
@@ -402,8 +434,17 @@ fn byte_to_perms(bits: u8) -> Vec<Permission> {
     perms
 }
 
-fn encode_ring_names(names: &[String]) -> Vec<u8> {
-    names.join("\0").into_bytes()
+fn encode_ring_names<'a>(names: impl Iterator<Item = &'a str>) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut first = true;
+    for name in names {
+        if !first {
+            buf.push(b'\0');
+        }
+        buf.extend_from_slice(name.as_bytes());
+        first = false;
+    }
+    buf
 }
 
 fn decode_ring_names(raw: &[u8]) -> Vec<String> {

--- a/src/backends/redb.rs
+++ b/src/backends/redb.rs
@@ -1,21 +1,25 @@
 //! Persistent registry backed by an embedded redb database.
 //!
-//! It defines two redb tables for the entire data model:
+//! Three redb tables make up the data model:
 //!
 //! ```text
-//! RINGS: maps ring names (&str) to lists of peers (EndpointIds, i.e. 32-byte Ed25519 pubkeys)
-//! RESOURCE_RINGS: maps resource ids (bytes) to NULL-separated ring names
+//! RINGS            ring_name → flat-concatenated peer-id bytes (32 B each)
+//! RESOURCE_RINGS   resource_id → NUL-separated ring names
+//! NICKNAMES        ring_name\0peer_id → display label (UTF-8)
+//! RESOURCE_RING_PERMS  [2B len][resource_id][ring_name] → permission bitfield (u8)
 //! ```
 //!
-//! The critical operation is [`RedbRegistry::is_allowed`], which answers:
-//! "may this EndpointId access this resource?" in a single read transaction.
+//! The critical operation is [`RedbRegistry::has_permission`], which answers
+//! "may this peer perform this operation on this resource?" in a single read
+//! transaction by checking ring membership and the permission bitfield.
 //!
 //! # Open ring
 //!
-//! `OPEN_RING_NAME` ("open") is a built-in, reserved ring name with a special
-//! meaning: **any peer may access a resource associated with the open ring**, regardless
-//! of membership. It is automatically created on first `open()` and cannot be
-//! deleted or renamed.
+//! `OPEN_RING_NAME` ("open") is a built-in, reserved ring name. Resources
+//! associated with it are readable by **any** peer regardless of membership.
+//! The open ring is read-only: associating it with `Write` or `Delete`
+//! permissions is rejected. It is bootstrapped on first `open()` and cannot
+//! be deleted or renamed.
 
 use std::{path::Path, sync::Arc};
 

--- a/src/backends/redb/migrations.rs
+++ b/src/backends/redb/migrations.rs
@@ -1,0 +1,204 @@
+//! Schema migrations for the redb registry backend.
+//!
+//! [`migrate`] is called by [`super::RedbRegistry::open`] on every startup.
+//! It reads the stored schema version from the [`META`] table and runs all
+//! pending migration steps in sequence. Each step executes in a single atomic
+//! transaction that also bumps the version, so a crash mid-migration leaves
+//! the database in a state where the step will be safely retried on the next
+//! startup.
+//!
+//! ## Version history
+//!
+//! | Version | Change |
+//! |---------|--------|
+//! | 0 | Initial schema: `RINGS`, `RESOURCE_RINGS`, `NICKNAMES`. No permission data. |
+//! | 1 | Added `RESOURCE_RING_PERMS`. All existing ring–resource associations are backfilled with `Read` permission. |
+
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
+
+use crate::Error;
+
+use super::{decode_ring_names, perm_key, storage, RESOURCE_RINGS, RESOURCE_RING_PERMS};
+
+/// Stores the single `schema_version` key.
+const META: TableDefinition<&str, u32> = TableDefinition::new("meta");
+const SCHEMA_VERSION_KEY: &str = "schema_version";
+
+/// The schema version this code targets. Bump when adding a new migration step.
+const CURRENT_VERSION: u32 = 1;
+
+/// Permission bitfield value for `Read`-only access.
+const READ_BIT: u8 = 0b001;
+
+/// Bring `db` up to [`CURRENT_VERSION`], running all pending migration steps.
+///
+/// Safe to call on a brand-new database (no data to backfill, only the version
+/// is written) or an already-current database (early return after reading the
+/// version).
+///
+/// # Errors
+///
+/// Returns [`Error::Storage`] if any read or write operation fails.
+pub(super) fn migrate(db: &Database) -> Result<(), Error> {
+    let version = read_version(db)?;
+    if version >= CURRENT_VERSION {
+        return Ok(());
+    }
+    if version < 1 {
+        v0_to_v1(db)?;
+    }
+    Ok(())
+}
+
+fn read_version(db: &Database) -> Result<u32, Error> {
+    let read = db.begin_read().map_err(storage)?;
+    match read.open_table(META) {
+        Ok(table) => Ok(table
+            .get(SCHEMA_VERSION_KEY)
+            .map_err(storage)?
+            .map(|v| v.value())
+            .unwrap_or(0)),
+        Err(redb::TableError::TableDoesNotExist(_)) => Ok(0),
+        Err(e) => Err(storage(e)),
+    }
+}
+
+/// Backfill [`RESOURCE_RING_PERMS`] for every existing ring–resource
+/// association, granting `Read` permission to all of them.
+///
+/// Before v1 the permission table did not exist; all associations are treated
+/// as read-only, which matches the only operation the protocol exposed at the
+/// time.
+///
+/// The schema version is bumped to `1` in the same transaction so the step is
+/// atomic: either both the backfill and the version bump commit, or neither does.
+fn v0_to_v1(db: &Database) -> Result<(), Error> {
+    let write = db.begin_write().map_err(storage)?;
+    {
+        // Collect all existing resource → [ring names] associations.
+        let rr_table = write.open_table(RESOURCE_RINGS).map_err(storage)?;
+        let mut entries: Vec<(Vec<u8>, Vec<String>)> = Vec::new();
+        for item in rr_table.iter().map_err(storage)? {
+            let (k, v) = item.map_err(storage)?;
+            entries.push((k.value().to_vec(), decode_ring_names(v.value())));
+        }
+        drop(rr_table);
+
+        // Backfill: write a Read-only permission row for every missing entry.
+        // The check for an existing row makes the step idempotent.
+        let mut perm_table = write.open_table(RESOURCE_RING_PERMS).map_err(storage)?;
+        for (resource_id, ring_names) in &entries {
+            for ring_name in ring_names {
+                let key = perm_key(resource_id, ring_name);
+                if perm_table.get(key.as_slice()).map_err(storage)?.is_none() {
+                    perm_table
+                        .insert(key.as_slice(), READ_BIT)
+                        .map_err(storage)?;
+                }
+            }
+        }
+        drop(perm_table);
+
+        // Bump schema version atomically with the data migration.
+        let mut meta = write.open_table(META).map_err(storage)?;
+        meta.insert(SCHEMA_VERSION_KEY, 1u32).map_err(storage)?;
+    }
+    write.commit().map_err(storage)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use redb::TableDefinition;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    const RINGS_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("rings");
+    const RESOURCE_RINGS_TABLE: TableDefinition<&[u8], &[u8]> =
+        TableDefinition::new("resource_rings");
+
+    fn open_bare(path: &std::path::Path) -> Database {
+        Database::create(path).unwrap()
+    }
+
+    /// Simulate an old-schema database: create the pre-v1 tables without
+    /// `RESOURCE_RING_PERMS` or `META`.
+    fn bootstrap_old_schema(db: &Database) {
+        let write = db.begin_write().unwrap();
+        write.open_table(RINGS_TABLE).unwrap();
+        write.open_table(RESOURCE_RINGS_TABLE).unwrap();
+        write
+            .open_table(TableDefinition::<&[u8], &str>::new("nicknames"))
+            .unwrap();
+        write.commit().unwrap();
+    }
+
+    /// Insert a ring–resource association directly into the old-schema tables.
+    fn insert_old_association(db: &Database, resource_id: &[u8], ring_name: &str) {
+        let write = db.begin_write().unwrap();
+        {
+            let mut rings = write.open_table(RINGS_TABLE).unwrap();
+            if rings.get(ring_name).unwrap().is_none() {
+                rings.insert(ring_name, &[][..]).unwrap();
+            }
+            drop(rings);
+            let mut rr = write.open_table(RESOURCE_RINGS_TABLE).unwrap();
+            rr.insert(resource_id, ring_name.as_bytes()).unwrap();
+        }
+        write.commit().unwrap();
+    }
+
+    #[test]
+    fn new_database_migrates_to_current_version() {
+        let dir = tempdir().unwrap();
+        let db = open_bare(&dir.path().join("test.redb"));
+        migrate(&db).unwrap();
+        assert_eq!(read_version(&db).unwrap(), CURRENT_VERSION);
+    }
+
+    #[test]
+    fn migration_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let db = open_bare(&dir.path().join("test.redb"));
+        migrate(&db).unwrap();
+        migrate(&db).unwrap();
+        assert_eq!(read_version(&db).unwrap(), CURRENT_VERSION);
+    }
+
+    #[test]
+    fn v0_data_gets_read_permission_backfilled() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.redb");
+        let resource_id = [0xabu8; 32];
+
+        {
+            let db = open_bare(&path);
+            bootstrap_old_schema(&db);
+            insert_old_association(&db, &resource_id, "friends");
+        }
+
+        let db = open_bare(&path);
+        migrate(&db).unwrap();
+
+        let read = db.begin_read().unwrap();
+        let perm_table = read.open_table(RESOURCE_RING_PERMS).unwrap();
+        let key = perm_key(&resource_id, "friends");
+        let bits = perm_table
+            .get(key.as_slice())
+            .unwrap()
+            .expect("perm row must exist after migration")
+            .value();
+        assert_eq!(bits & READ_BIT, READ_BIT, "Read bit must be set");
+    }
+
+    #[test]
+    fn already_current_database_is_not_modified() {
+        let dir = tempdir().unwrap();
+        let db = open_bare(&dir.path().join("test.redb"));
+        migrate(&db).unwrap();
+        let version_before = read_version(&db).unwrap();
+        migrate(&db).unwrap();
+        assert_eq!(read_version(&db).unwrap(), version_before);
+    }
+}

--- a/src/backends/redb/mod.rs
+++ b/src/backends/redb/mod.rs
@@ -21,6 +21,8 @@
 //! permissions is rejected. It is bootstrapped on first `open()` and cannot
 //! be deleted or renamed.
 
+mod migrations;
+
 use std::{path::Path, sync::Arc};
 
 use iroh::EndpointId;
@@ -81,6 +83,7 @@ impl RedbRegistry {
             }
         }
         write.commit().map_err(storage)?;
+        migrations::migrate(&db)?;
         Ok(Self { db: Arc::new(db) })
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,13 @@ pub enum Error {
     #[error("unknown operation byte: {0:#04x}")]
     UnknownOperationByte(u8),
 
+    /// The open ring may only be associated with [`Permission::Read`](crate::Permission::Read).
+    ///
+    /// Granting Write or Delete to the open ring would allow any unauthenticated peer
+    /// to modify or disassociate resources.
+    #[error("the open ring may only be associated with Read permission")]
+    OpenRingReadOnly,
+
     /// A ring–resource association was requested with an empty permission set.
     ///
     /// Every association must grant at least one [`Permission`](crate::Permission);

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,13 @@ pub enum Error {
     #[error("unexpected status byte: {0:#04x}")]
     UnknownStatusByte(u8),
 
+    /// A ring–resource association was requested with an empty permission set.
+    ///
+    /// Every association must grant at least one [`Permission`](crate::Permission);
+    /// an empty set is meaningless and is rejected as a programming error.
+    #[error("permission set must not be empty")]
+    EmptyPermissionSet,
+
     /// An underlying storage backend returned an error.
     #[error("storage error: {0}")]
     Storage(Box<dyn std::error::Error + Send + Sync + 'static>),

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,10 @@ pub enum Error {
     #[error("unexpected status byte: {0:#04x}")]
     UnknownStatusByte(u8),
 
+    /// The operation byte received on the wire was not a recognised [`Permission`](crate::Permission).
+    #[error("unknown operation byte: {0:#04x}")]
+    UnknownOperationByte(u8),
+
     /// A ring–resource association was requested with an empty permission set.
     ///
     /// Every association must grant at least one [`Permission`](crate::Permission);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,30 @@
 #![warn(missing_docs)]
 #![warn(unreachable_pub)]
 
-//! Ring-based access control for resources over iroh protocols.
+//! Ring-based, permission-typed access control for resources over iroh protocols.
 //!
-//! A **ring** is a named group of peers. Resources are associated with one or more
-//! rings; a peer is granted access if it belongs to at least one of those rings.
-//! The built-in [`OPEN_RING_NAME`] ring grants access to everyone, regardless of
-//! membership.
+//! A **ring** is a named group of peers. Resources are associated with rings together
+//! with a set of [`Permission`]s; every member of a ring inherits those permissions on
+//! the resource. There are no per-peer overrides — rings are the single access-control
+//! unit.
+//!
+//! Three permissions cover the operations a remote peer may request:
+//!
+//! | [`Permission`] | Remote operation |
+//! |---|---|
+//! | `Read`   | Download the resource |
+//! | `Write`  | Push or update the resource (only into rings the peer belongs to) |
+//! | `Delete` | Remove the ring–resource association (underlying data is untouched) |
+//!
+//! The built-in [`OPEN_RING_NAME`] ring is read-only: it grants [`Permission::Read`]
+//! to any peer regardless of membership.
 //!
 //! # Quick start
 //!
 //! 1. Choose a [`Registry`] backend ([`InMemoryRegistry`] or [`RedbRegistry`]).
 //! 2. Create rings and add peers with [`Registry::create_ring`] /
 //!    [`Registry::add_peer_to_ring`].
-//! 3. Associate resources with rings via [`Registry::add_ring_to_resource`].
+//! 3. Associate resources with rings and permissions via [`Registry::add_ring_to_resource`].
 //! 4. Wrap your iroh endpoint with a [`protocol::RingGate`] to enforce access
 //!    control on every incoming connection.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod transfers;
 mod ring;
 
 pub use error::Error;
+#[doc(inline)]
 pub use protocol::{RingGate, Transfer, RINGS_ALPN as ALPN};
 pub use registry::{Registry, ResourceId};
 pub use ring::{Ring, OPEN_RING_NAME};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ mod ring;
 pub use error::Error;
 #[doc(inline)]
 pub use protocol::{RingGate, Transfer, RINGS_ALPN as ALPN};
-pub use registry::{Registry, ResourceId};
+pub use registry::{Permission, Registry, ResourceId};
 pub use ring::{Ring, OPEN_RING_NAME};
 
 #[cfg(feature = "mem")]

--- a/src/protocol/gate.rs
+++ b/src/protocol/gate.rs
@@ -156,7 +156,7 @@ impl<R: Registry + Clone + Send + Sync + 'static, T: Transfer> RingGate<R, T> {
             .registry
             .has_permission(&peer, &resource_id, permission)
             .unwrap_or(false)
-            || self.transfer.can_access(&peer, &resource_id).await;
+            && self.transfer.can_access(&peer, &resource_id).await;
 
         if !allowed {
             warn!(%peer, resource_id = %hex::encode(&resource_id), "DENIED");

--- a/src/protocol/gate.rs
+++ b/src/protocol/gate.rs
@@ -30,7 +30,7 @@ use iroh::{
 };
 use tracing::{debug, info, instrument, warn};
 
-use crate::registry::Registry;
+use crate::registry::{Permission, Registry};
 
 use super::{Status, MAX_RESOURCE_ID_BYTES};
 
@@ -140,7 +140,7 @@ impl<R: Registry + Clone + Send + Sync + 'static, T: Transfer> RingGate<R, T> {
 
         let allowed = self
             .registry
-            .is_allowed(&peer, &resource_id)
+            .has_permission(&peer, &resource_id, Permission::Read)
             .unwrap_or(false)
             || self.transfer.can_access(&peer, &resource_id).await;
 

--- a/src/protocol/gate.rs
+++ b/src/protocol/gate.rs
@@ -30,9 +30,9 @@ use iroh::{
 };
 use tracing::{debug, info, instrument, warn};
 
-use crate::registry::{Permission, Registry};
+use crate::registry::Registry;
 
-use super::{Status, MAX_RESOURCE_ID_BYTES};
+use super::{parse_operation, Status, MAX_RESOURCE_ID_BYTES};
 
 /// Defines the sub-protocol that runs after the gate grants access.
 ///
@@ -136,11 +136,25 @@ impl<R: Registry + Clone + Send + Sync + 'static, T: Transfer> RingGate<R, T> {
             .await
             .context("reading resource_id")?;
 
-        debug!(%peer, resource_id = %hex::encode(&resource_id), "request received");
+        let mut op_buf = [0u8; 1];
+        recv.read_exact(&mut op_buf)
+            .await
+            .context("reading operation byte")?;
+        let permission = match parse_operation(op_buf[0]) {
+            Ok(p) => p,
+            Err(_) => {
+                warn!(%peer, byte = op_buf[0], "unknown operation byte");
+                send.write_all(&[Status::Denied as u8]).await?;
+                send.finish()?;
+                return Ok(());
+            }
+        };
+
+        debug!(%peer, resource_id = %hex::encode(&resource_id), ?permission, "request received");
 
         let allowed = self
             .registry
-            .has_permission(&peer, &resource_id, Permission::Read)
+            .has_permission(&peer, &resource_id, permission)
             .unwrap_or(false)
             || self.transfer.can_access(&peer, &resource_id).await;
 

--- a/src/protocol/gate.rs
+++ b/src/protocol/gate.rs
@@ -1,7 +1,7 @@
 //! [`RingGate`]: the iroh [`ProtocolHandler`] that enforces ring-based access control.
 //!
 //! When a peer opens a bi-directional stream, [`RingGate`] reads the
-//! length-prefixed resource id, checks [`Registry::is_allowed`] (and [`Transfer::can_access`]
+//! length-prefixed resource id, checks [`Registry::has_permission`] (and [`Transfer::can_access`]
 //! for application-level checks), then either closes the stream with a DENIED
 //! byte or writes ALLOWED and delegates the rest of the stream to the
 //! [`Transfer`] concrete implementations.

--- a/src/protocol/gate.rs
+++ b/src/protocol/gate.rs
@@ -156,7 +156,7 @@ impl<R: Registry + Clone + Send + Sync + 'static, T: Transfer> RingGate<R, T> {
             .registry
             .has_permission(&peer, &resource_id, permission)
             .unwrap_or(false)
-            && self.transfer.can_access(&peer, &resource_id).await;
+            || self.transfer.can_access(&peer, &resource_id).await;
 
         if !allowed {
             warn!(%peer, resource_id = %hex::encode(&resource_id), "DENIED");

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,4 +1,4 @@
-//! Wire protocol for `/iroh-rings/1`.
+//! Wire protocol for `/iroh-rings/2`.
 //!
 //! # Wire protocol
 //!
@@ -6,6 +6,7 @@
 //! Request (initiator peer -> gate)
 //!  [ 2 B]  u16-le: resource id length (N)
 //!  [ N B]  resource id bytes
+//!  [ 1 B]  operation: 0x01 = Read, 0x02 = Write, 0x03 = Delete
 //!
 //! Response (gate -> initiator peer)
 //!  [ 1 B]  status: 0x00 = DENIED, 0x01 = ALLOWED
@@ -18,8 +19,10 @@ mod gate;
 
 pub use gate::{RingGate, Transfer};
 
+use crate::registry::Permission;
+
 /// ALPN identifier used to negotiate the iroh-rings protocol during the QUIC handshake.
-pub const RINGS_ALPN: &[u8] = b"/iroh-rings/1";
+pub const RINGS_ALPN: &[u8] = b"/iroh-rings/2";
 
 /// Maximum number of bytes accepted for a resource id on the wire.
 ///
@@ -27,22 +30,46 @@ pub const RINGS_ALPN: &[u8] = b"/iroh-rings/1";
 /// trigger an unbounded allocation by sending a large length field.
 pub const MAX_RESOURCE_ID_BYTES: usize = 256;
 
-/// Encodes a resource id request for sending to a [`RingGate`].
+/// Encodes a resource request for sending to a [`RingGate`].
 ///
-/// Writes `[u16-le length][resource_id bytes]` into a new buffer.
+/// Writes `[u16-le length][resource_id bytes][operation byte]` into a new buffer.
 ///
 /// # Errors
 ///
 /// Returns an error if `resource_id.len()` exceeds [`MAX_RESOURCE_ID_BYTES`].
-pub fn encode_request(resource_id: &[u8]) -> Result<Vec<u8>, crate::Error> {
+pub fn encode_request(resource_id: &[u8], permission: Permission) -> Result<Vec<u8>, crate::Error> {
     if resource_id.len() > MAX_RESOURCE_ID_BYTES {
         return Err(crate::Error::ResourceIdTooLong(resource_id.len()));
     }
     let len = resource_id.len() as u16;
-    let mut out = Vec::with_capacity(std::mem::size_of::<u16>() + resource_id.len());
+    let mut out = Vec::with_capacity(std::mem::size_of::<u16>() + resource_id.len() + 1);
     out.extend_from_slice(&len.to_le_bytes());
     out.extend_from_slice(resource_id);
+    out.push(encode_operation(permission));
     Ok(out)
+}
+
+/// Maps a [`Permission`] to its wire byte representation.
+pub(crate) fn encode_operation(permission: Permission) -> u8 {
+    match permission {
+        Permission::Read => 0x01,
+        Permission::Write => 0x02,
+        Permission::Delete => 0x03,
+    }
+}
+
+/// Parses a wire operation byte into a [`Permission`].
+///
+/// # Errors
+///
+/// Returns [`crate::Error::UnknownOperationByte`] if the byte does not map to a known operation.
+pub(crate) fn parse_operation(byte: u8) -> Result<Permission, crate::Error> {
+    match byte {
+        0x01 => Ok(Permission::Read),
+        0x02 => Ok(Permission::Write),
+        0x03 => Ok(Permission::Delete),
+        _ => Err(crate::Error::UnknownOperationByte(byte)),
+    }
 }
 
 /// Gate response byte sent to the initiator after a resource request.
@@ -97,38 +124,76 @@ mod tests {
 
     #[test]
     fn encode_request_empty_resource_id_writes_zero_length_header() {
-        let encoded = encode_request(&[]).unwrap();
-        assert_eq!(encoded.len(), 2);
+        let encoded = encode_request(&[], Permission::Read).unwrap();
+        assert_eq!(encoded.len(), 3); // 2B len + 0B id + 1B op
         assert_eq!(u16::from_le_bytes(encoded[..2].try_into().unwrap()), 0);
+        assert_eq!(encoded[2], encode_operation(Permission::Read));
     }
 
     #[test]
     fn encode_request_32_byte_id_round_trips() {
         let id = [0xabu8; 32];
-        let encoded = encode_request(&id).unwrap();
+        let encoded = encode_request(&id, Permission::Read).unwrap();
         let len = u16::from_le_bytes(encoded[..2].try_into().unwrap()) as usize;
         assert_eq!(len, 32);
-        assert_eq!(&encoded[2..], &id);
+        assert_eq!(&encoded[2..2 + 32], &id);
+        assert_eq!(encoded[2 + 32], encode_operation(Permission::Read));
     }
 
     #[test]
-    fn encode_request_16_byte_id_round_trips() {
-        let id = [0x42u8; 16];
-        let encoded = encode_request(&id).unwrap();
-        let len = u16::from_le_bytes(encoded[..2].try_into().unwrap()) as usize;
-        assert_eq!(len, 16);
-        assert_eq!(&encoded[2..], &id);
+    fn encode_request_write_operation_sets_correct_byte() {
+        let id = [0x01u8; 16];
+        let encoded = encode_request(&id, Permission::Write).unwrap();
+        assert_eq!(
+            *encoded.last().unwrap(),
+            encode_operation(Permission::Write)
+        );
+    }
+
+    #[test]
+    fn encode_request_delete_operation_sets_correct_byte() {
+        let id = [0x01u8; 16];
+        let encoded = encode_request(&id, Permission::Delete).unwrap();
+        assert_eq!(
+            *encoded.last().unwrap(),
+            encode_operation(Permission::Delete)
+        );
     }
 
     #[test]
     fn encode_request_rejects_oversized_resource_id() {
         let id = vec![0u8; MAX_RESOURCE_ID_BYTES + 1];
-        assert!(encode_request(&id).is_err());
+        assert!(encode_request(&id, Permission::Read).is_err());
     }
 
     #[test]
     fn encode_request_accepts_maximum_size_resource_id() {
         let id = vec![0u8; MAX_RESOURCE_ID_BYTES];
-        assert!(encode_request(&id).is_ok());
+        assert!(encode_request(&id, Permission::Read).is_ok());
+    }
+
+    #[test]
+    fn operation_bytes_are_distinct() {
+        assert_ne!(
+            encode_operation(Permission::Read),
+            encode_operation(Permission::Write)
+        );
+        assert_ne!(
+            encode_operation(Permission::Write),
+            encode_operation(Permission::Delete)
+        );
+    }
+
+    #[test]
+    fn parse_operation_round_trips() {
+        for p in [Permission::Read, Permission::Write, Permission::Delete] {
+            assert_eq!(parse_operation(encode_operation(p)).unwrap(), p);
+        }
+    }
+
+    #[test]
+    fn parse_operation_unknown_byte_errors() {
+        assert!(parse_operation(0x00).is_err());
+        assert!(parse_operation(0xff).is_err());
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -210,6 +210,27 @@ pub trait Registry {
     ) -> Result<bool, Error>;
 }
 
+#[cfg(any(feature = "mem", feature = "redb"))]
+/// Validates that `permissions` is non-empty and that the open ring is only paired with `Read`.
+///
+/// Both backends call this as the first step of `add_ring_to_resource`.
+///
+/// # Errors
+///
+/// Returns [`Error::EmptyPermissionSet`] or [`Error::OpenRingReadOnly`].
+pub(crate) fn validate_ring_permissions(
+    ring_name: &str,
+    permissions: &[Permission],
+) -> Result<(), Error> {
+    if permissions.is_empty() {
+        return Err(Error::EmptyPermissionSet);
+    }
+    if ring_name == OPEN_RING_NAME && permissions.iter().any(|p| !matches!(p, Permission::Read)) {
+        return Err(Error::OpenRingReadOnly);
+    }
+    Ok(())
+}
+
 /// Compute the updated ring–permission list when associating `ring_name` with a resource.
 ///
 /// If `ring_name` is [`OPEN_RING_NAME`], all private rings are replaced with only
@@ -443,6 +464,23 @@ pub fn registry_contract<R: Registry>(reg: &R) {
     assert!(rings_d
         .iter()
         .any(|(r, _)| r == &Ring::new("ring_e").unwrap()));
+
+    // permissions of an existing ring survive when a second ring is added to the same resource
+    let res_perm_survival = make_resource(0x06);
+    let peer_survival = make_peer();
+    reg.create_ring("survival_a").unwrap();
+    reg.create_ring("survival_b").unwrap();
+    reg.add_peer_to_ring("survival_a", peer_survival, None)
+        .unwrap();
+    reg.add_ring_to_resource(res_perm_survival, "survival_a", &[Permission::Read])
+        .unwrap();
+    reg.add_ring_to_resource(res_perm_survival, "survival_b", &[Permission::Write])
+        .unwrap();
+    assert!(
+        reg.has_permission(&peer_survival, &res_perm_survival, Permission::Read)
+            .unwrap(),
+        "survival_a Read permission must survive adding survival_b to the same resource",
+    );
 
     // --- nicknames ---
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -354,6 +354,25 @@ pub fn registry_contract<R: Registry>(reg: &R) {
         .add_ring_to_resource(make_resource(0xfd), "ghost", &[Permission::Read])
         .is_err());
 
+    // open ring rejects Write and Delete permissions
+    let res_open_guard = make_resource(0xb0);
+    assert!(reg
+        .add_ring_to_resource(res_open_guard, OPEN_RING_NAME, &[Permission::Write])
+        .is_err());
+    assert!(reg
+        .add_ring_to_resource(res_open_guard, OPEN_RING_NAME, &[Permission::Delete])
+        .is_err());
+    assert!(reg
+        .add_ring_to_resource(
+            res_open_guard,
+            OPEN_RING_NAME,
+            &[Permission::Read, Permission::Write]
+        )
+        .is_err());
+    assert!(reg
+        .add_ring_to_resource(res_open_guard, OPEN_RING_NAME, &[Permission::Read])
+        .is_ok());
+
     // open ring clears all private rings
     let res_a = make_resource(0x02);
     reg.create_ring("ring_a").unwrap();

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -28,6 +28,30 @@ use iroh::EndpointId;
 use crate::ring::{Ring, OPEN_RING_NAME};
 use crate::Error;
 
+/// An operation a peer may request on a resource.
+///
+/// Permissions are granted per ring–resource association: all members of a ring
+/// share the same permission set on a given resource. There are no per-peer overrides.
+///
+/// The local registry owner implicitly holds all permissions on their own registry;
+/// this enum governs what is delegated to remote peers.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Permission {
+    /// Download a resource from the remote peer's registry.
+    Read,
+    /// Push or update a resource in a ring the peer is already a member of.
+    ///
+    /// A peer may only write into rings they belong to — WRITE does not bypass
+    /// ring membership.
+    Write,
+    /// Remove the ring–resource association from the remote peer's registry.
+    ///
+    /// This does not destroy the underlying resource data. True deletion is a
+    /// local-only operation reserved for the registry owner.
+    Delete,
+}
+
 /// A type that identifies a resource by a byte sequence,
 /// which is supposed to be unique.
 ///

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -5,17 +5,36 @@
 //! - [`ResourceId`] — identifies a resource by a stable byte sequence.
 //! - [`Registry`] — manages rings, peer membership, and resource–ring associations.
 //!
-//! The access-control rule is simple: a peer may access a resource if it belongs
-//! to at least one ring associated with that resource, or if the built-in open
-//! ring (`"open"`) is associated with it (which grants access to everyone).
+//! # Permission model
+//!
+//! Permissions are attached to ring–resource associations: when you associate a ring
+//! with a resource you also declare which [`Permission`]s that ring grants on it.
+//! Every member of the ring inherits those permissions — there are no per-peer
+//! overrides. Rings are the single access-control unit.
+//!
+//! The three permissions map to the operations a remote peer may request:
+//!
+//! | [`Permission`] | Remote operation |
+//! |---|---|
+//! | `Read`   | Download the resource |
+//! | `Write`  | Push or update the resource (only into rings the peer belongs to) |
+//! | `Delete` | Remove the ring–resource association (underlying data is untouched) |
+//!
+//! The local registry owner implicitly holds all permissions on their own registry;
+//! this trait governs what is delegated to remote peers.
+//!
+//! The built-in open ring (`"open"`) is read-only: it grants [`Permission::Read`] to
+//! any peer regardless of membership, and may not be associated with `Write` or
+//! `Delete`. Associating the open ring with a resource replaces all private rings;
+//! adding a private ring removes the open ring.
 //!
 //! # Security model
 //!
-//! The registry enforces **what** is allowed: which peers may access which
-//! resources, as declared by the operator. It does not authenticate **who** is
+//! The registry enforces **what** is allowed: which peers may perform which operations
+//! on which resources, as declared by the operator. It does not authenticate **who** is
 //! speaking — that is guaranteed by the transport layer (QUIC/TLS 1.3) before
 //! the gate ever consults the registry. Custom backend implementations can
-//! therefore trust that the [`EndpointId`] passed to [`Registry::is_allowed`]
+//! therefore trust that the [`EndpointId`] passed to [`Registry::has_permission`]
 //! has already been verified.
 //!
 //! # Implementing a custom backend
@@ -78,8 +97,10 @@ impl ResourceId for Vec<u8> {
 /// Manages rings, their peer membership, and the association between
 /// resources and rings.
 ///
-/// A peer is granted access to a resource if it belongs to at least one ring
-/// associated with that resource, or if the open ring (`"open"`) is associated with it.
+/// Access is governed by [`Permission`]-typed ring–resource associations.
+/// A peer may perform an operation on a resource if it belongs to at least one
+/// ring associated with that resource which grants the corresponding permission,
+/// or if the open ring (`"open"`) is associated with it and grants that permission.
 ///
 /// Use `registry_contract` in tests to verify that a custom backend
 /// satisfies the required behavioural invariants.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -25,8 +25,9 @@
 //!
 //! The built-in open ring (`"open"`) is read-only: it grants [`Permission::Read`] to
 //! any peer regardless of membership, and may not be associated with `Write` or
-//! `Delete`. Associating the open ring with a resource replaces all private rings;
-//! adding a private ring removes the open ring.
+//! `Delete`. The open ring and private rings may coexist on the same resource —
+//! a resource can be publicly readable (via the open ring) while remaining
+//! writable or deletable only by members of a private ring.
 //!
 //! # Security model
 //!
@@ -44,7 +45,9 @@
 
 use iroh::EndpointId;
 
-use crate::ring::{Ring, OPEN_RING_NAME};
+use crate::ring::Ring;
+#[cfg(any(feature = "mem", feature = "redb", test))]
+use crate::ring::OPEN_RING_NAME;
 use crate::Error;
 
 /// An operation a peer may request on a resource.
@@ -233,28 +236,19 @@ pub(crate) fn validate_ring_permissions(
 
 /// Compute the updated ring–permission list when associating `ring_name` with a resource.
 ///
-/// If `ring_name` is [`OPEN_RING_NAME`], all private rings are replaced with only
-/// the open ring and its permissions. Otherwise, the open ring is removed and
-/// `ring_name` is inserted (or its permissions updated if already present).
+/// If `ring_name` is already in `existing` its permission set is replaced; otherwise
+/// it is appended. The open ring and private rings may coexist on the same resource.
 pub fn compute_resource_rings(
-    existing: Vec<(String, Vec<Permission>)>,
+    mut existing: Vec<(String, Vec<Permission>)>,
     ring_name: &str,
     permissions: Vec<Permission>,
 ) -> Vec<(String, Vec<Permission>)> {
-    if ring_name == OPEN_RING_NAME {
-        vec![(OPEN_RING_NAME.to_string(), permissions)]
+    if let Some(entry) = existing.iter_mut().find(|(n, _)| n == ring_name) {
+        entry.1 = permissions;
     } else {
-        let mut kept: Vec<(String, Vec<Permission>)> = existing
-            .into_iter()
-            .filter(|(n, _)| n != OPEN_RING_NAME)
-            .collect();
-        if let Some(entry) = kept.iter_mut().find(|(n, _)| n == ring_name) {
-            entry.1 = permissions;
-        } else {
-            kept.push((ring_name.to_string(), permissions));
-        }
-        kept
+        existing.push((ring_name.to_string(), permissions));
     }
+    existing
 }
 
 /// Shared contract test, to be run against every [`Registry`] implementation:
@@ -359,6 +353,9 @@ pub fn registry_contract<R: Registry>(reg: &R) {
     assert!(!reg
         .has_permission(&stranger, &resource, Permission::Write)
         .unwrap()); // but not WRITE
+    assert!(reg
+        .has_permission(&bob, &resource, Permission::Write)
+        .unwrap()); // friends ring Write survives adding the open ring
 
     let resource_multi = make_resource(0x01);
     let peer_work = make_peer();
@@ -415,27 +412,49 @@ pub fn registry_contract<R: Registry>(reg: &R) {
         .add_ring_to_resource(res_open_guard, OPEN_RING_NAME, &[Permission::Read])
         .is_ok());
 
-    // open ring clears all private rings
+    // open ring and private rings coexist on the same resource
     let res_a = make_resource(0x02);
     reg.create_ring("ring_a").unwrap();
-    reg.add_ring_to_resource(res_a, "ring_a", &[Permission::Read])
+    reg.add_ring_to_resource(res_a, "ring_a", &[Permission::Write])
         .unwrap();
     reg.add_ring_to_resource(res_a, OPEN_RING_NAME, &[Permission::Read])
         .unwrap();
     let rings_a = reg.list_resource_rings(res_a).unwrap();
-    assert_eq!(rings_a.len(), 1);
-    assert_eq!(rings_a[0].0, Ring::new_open());
+    assert_eq!(rings_a.len(), 2);
+    assert!(rings_a.iter().any(|(r, _)| r.is_open()));
+    assert!(rings_a
+        .iter()
+        .any(|(r, _)| r == &Ring::new("ring_a").unwrap()));
 
-    // private ring clears the open ring
+    // any peer can read via the open ring; only ring_a members can write
+    let ring_a_peer = make_peer();
+    reg.add_peer_to_ring("ring_a", ring_a_peer, None).unwrap();
+    let outsider = make_peer();
+    assert!(reg
+        .has_permission(&outsider, &res_a, Permission::Read)
+        .unwrap());
+    assert!(!reg
+        .has_permission(&outsider, &res_a, Permission::Write)
+        .unwrap());
+    assert!(reg
+        .has_permission(&ring_a_peer, &res_a, Permission::Read)
+        .unwrap());
+    assert!(reg
+        .has_permission(&ring_a_peer, &res_a, Permission::Write)
+        .unwrap());
+
+    // adding the open ring to a resource that already has private rings keeps both
     let res_b = make_resource(0x03);
     reg.create_ring("ring_b").unwrap();
-    reg.add_ring_to_resource(res_b, OPEN_RING_NAME, &[Permission::Read])
-        .unwrap();
     reg.add_ring_to_resource(res_b, "ring_b", &[Permission::Read])
         .unwrap();
+    reg.add_ring_to_resource(res_b, OPEN_RING_NAME, &[Permission::Read])
+        .unwrap();
     let rings_b = reg.list_resource_rings(res_b).unwrap();
-    assert_eq!(rings_b.len(), 1);
-    assert_eq!(rings_b[0].0, Ring::new("ring_b").unwrap());
+    assert_eq!(rings_b.len(), 2);
+    assert!(reg
+        .has_permission(&outsider, &res_b, Permission::Read)
+        .unwrap()); // non-member can read via open ring
 
     // associating the same ring twice updates its permissions
     let res_c = make_resource(0x04);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -143,7 +143,8 @@ pub trait Registry {
     fn remove_ring_from_resource<ResId: ResourceId>(&self, resource_id: ResId)
         -> Result<(), Error>;
 
-    /// Returns the rings currently associated with a resource.
+    /// Returns the rings currently associated with a resource, together with
+    /// the permission set each ring grants on it.
     ///
     /// # Errors
     ///
@@ -151,50 +152,64 @@ pub trait Registry {
     fn list_resource_rings<ResId: ResourceId>(
         &self,
         resource_id: ResId,
-    ) -> Result<Vec<Ring>, Error>;
+    ) -> Result<Vec<(Ring, Vec<Permission>)>, Error>;
 
-    /// Associates a resource with a ring, granting ring members access to it.
+    /// Associates a resource with a ring and grants the specified permissions
+    /// to all members of that ring.
+    ///
+    /// If the ring is already associated with the resource, its permission set
+    /// is replaced with the new one.
     ///
     /// # Errors
     ///
-    /// Returns [`Error::RingNotFound`] if the ring does not exist, or
+    /// Returns [`Error::EmptyPermissionSet`] if `permissions` is empty,
+    /// [`Error::RingNotFound`] if the ring does not exist, or
     /// [`Error::Storage`] on a backend I/O failure.
     fn add_ring_to_resource<ResId: ResourceId>(
         &self,
         resource_id: ResId,
         ring_name: &str,
+        permissions: &[Permission],
     ) -> Result<(), Error>;
 
-    /// Returns `true` if `peer` is allowed to access `resource_id`.
+    /// Returns `true` if `peer` holds `permission` on `resource_id`.
     ///
-    /// A peer is allowed if it belongs to at least one ring associated with the
-    /// resource, or if the open ring is associated with it.
+    /// A peer holds a permission if it belongs to at least one ring associated
+    /// with the resource that grants that permission — or if the open ring is
+    /// associated with the resource and grants it (which applies to any peer).
     ///
     /// # Errors
     ///
     /// Returns [`Error::Storage`] on a backend I/O failure.
-    fn is_allowed<ResId: ResourceId>(
+    fn has_permission<ResId: ResourceId>(
         &self,
         peer: &EndpointId,
         resource_id: &ResId,
+        permission: Permission,
     ) -> Result<bool, Error>;
 }
 
-/// Compute the updated ring list when associating `ring_name` with a resource.
+/// Compute the updated ring–permission list when associating `ring_name` with a resource.
 ///
 /// If `ring_name` is [`OPEN_RING_NAME`], all private rings are replaced with only
-/// the open ring. Otherwise, the open ring is removed and `ring_name` is appended
-/// if not already present.
-pub fn compute_resource_rings(existing: Vec<String>, ring_name: &str) -> Vec<String> {
+/// the open ring and its permissions. Otherwise, the open ring is removed and
+/// `ring_name` is inserted (or its permissions updated if already present).
+pub fn compute_resource_rings(
+    existing: Vec<(String, Vec<Permission>)>,
+    ring_name: &str,
+    permissions: Vec<Permission>,
+) -> Vec<(String, Vec<Permission>)> {
     if ring_name == OPEN_RING_NAME {
-        vec![OPEN_RING_NAME.to_string()]
+        vec![(OPEN_RING_NAME.to_string(), permissions)]
     } else {
-        let mut kept: Vec<String> = existing
+        let mut kept: Vec<(String, Vec<Permission>)> = existing
             .into_iter()
-            .filter(|n| n != OPEN_RING_NAME)
+            .filter(|(n, _)| n != OPEN_RING_NAME)
             .collect();
-        if !kept.iter().any(|n| n == ring_name) {
-            kept.push(ring_name.to_string());
+        if let Some(entry) = kept.iter_mut().find(|(n, _)| n == ring_name) {
+            entry.1 = permissions;
+        } else {
+            kept.push((ring_name.to_string(), permissions));
         }
         kept
     }
@@ -258,32 +273,76 @@ pub fn registry_contract<R: Registry>(reg: &R) {
     reg.remove_peer_from_ring("friends", extra).unwrap(); // noop when not a member
     assert_eq!(reg.list_ring_peers("friends").unwrap().len(), 0);
 
-    // --- is_allowed ---
+    // --- has_permission ---
 
     let resource = make_resource(0xab);
     let bob = make_peer();
-    assert!(!reg.is_allowed(&bob, &resource).unwrap()); // no associations → denied
+    // no associations → all permissions denied
+    assert!(!reg
+        .has_permission(&bob, &resource, Permission::Read)
+        .unwrap());
+    assert!(!reg
+        .has_permission(&bob, &resource, Permission::Write)
+        .unwrap());
+    assert!(!reg
+        .has_permission(&bob, &resource, Permission::Delete)
+        .unwrap());
 
     reg.add_peer_to_ring("friends", bob, None).unwrap();
-    reg.add_ring_to_resource(resource, "friends").unwrap();
-    assert!(reg.is_allowed(&bob, &resource).unwrap()); // ring member allowed
+    reg.add_ring_to_resource(resource, "friends", &[Permission::Read])
+        .unwrap();
+    assert!(reg
+        .has_permission(&bob, &resource, Permission::Read)
+        .unwrap()); // ring member with READ
+    assert!(!reg
+        .has_permission(&bob, &resource, Permission::Write)
+        .unwrap()); // no WRITE granted
+
+    reg.add_ring_to_resource(resource, "friends", &[Permission::Read, Permission::Write])
+        .unwrap();
+    assert!(reg
+        .has_permission(&bob, &resource, Permission::Write)
+        .unwrap()); // permissions updated
 
     let stranger = make_peer();
-    assert!(!reg.is_allowed(&stranger, &resource).unwrap()); // non-member denied
+    assert!(!reg
+        .has_permission(&stranger, &resource, Permission::Read)
+        .unwrap()); // non-member denied
 
-    reg.add_ring_to_resource(resource, OPEN_RING_NAME).unwrap();
-    assert!(reg.is_allowed(&stranger, &resource).unwrap()); // open ring allows anyone
+    reg.add_ring_to_resource(resource, OPEN_RING_NAME, &[Permission::Read])
+        .unwrap();
+    assert!(reg
+        .has_permission(&stranger, &resource, Permission::Read)
+        .unwrap()); // open ring allows anyone for READ
+    assert!(!reg
+        .has_permission(&stranger, &resource, Permission::Write)
+        .unwrap()); // but not WRITE
 
     let resource_multi = make_resource(0x01);
     let peer_work = make_peer();
-    reg.add_ring_to_resource(resource_multi, "friends").unwrap();
-    reg.add_ring_to_resource(resource_multi, "work").unwrap();
+    reg.add_ring_to_resource(resource_multi, "friends", &[Permission::Read])
+        .unwrap();
+    reg.add_ring_to_resource(
+        resource_multi,
+        "work",
+        &[Permission::Read, Permission::Write],
+    )
+    .unwrap();
     reg.add_peer_to_ring("work", peer_work, None).unwrap();
-    assert!(reg.is_allowed(&peer_work, &resource_multi).unwrap()); // member of any associated ring
+    assert!(reg
+        .has_permission(&peer_work, &resource_multi, Permission::Write)
+        .unwrap()); // member of ring with WRITE
 
     reg.remove_ring_from_resource(resource).unwrap();
     assert_eq!(reg.list_resource_rings(resource).unwrap().len(), 0);
-    assert!(!reg.is_allowed(&stranger, &resource).unwrap());
+    assert!(!reg
+        .has_permission(&stranger, &resource, Permission::Read)
+        .unwrap());
+
+    // empty permission set is rejected
+    assert!(reg
+        .add_ring_to_resource(make_resource(0xac), "friends", &[])
+        .is_err());
 
     // --- resource–ring association semantics ---
 
@@ -292,46 +351,58 @@ pub fn registry_contract<R: Registry>(reg: &R) {
         vec![]
     );
     assert!(reg
-        .add_ring_to_resource(make_resource(0xfd), "ghost")
+        .add_ring_to_resource(make_resource(0xfd), "ghost", &[Permission::Read])
         .is_err());
 
     // open ring clears all private rings
     let res_a = make_resource(0x02);
     reg.create_ring("ring_a").unwrap();
-    reg.add_ring_to_resource(res_a, "ring_a").unwrap();
-    reg.add_ring_to_resource(res_a, OPEN_RING_NAME).unwrap();
-    assert_eq!(
-        reg.list_resource_rings(res_a).unwrap(),
-        vec![Ring::new_open()]
-    );
+    reg.add_ring_to_resource(res_a, "ring_a", &[Permission::Read])
+        .unwrap();
+    reg.add_ring_to_resource(res_a, OPEN_RING_NAME, &[Permission::Read])
+        .unwrap();
+    let rings_a = reg.list_resource_rings(res_a).unwrap();
+    assert_eq!(rings_a.len(), 1);
+    assert_eq!(rings_a[0].0, Ring::new_open());
 
     // private ring clears the open ring
     let res_b = make_resource(0x03);
     reg.create_ring("ring_b").unwrap();
-    reg.add_ring_to_resource(res_b, OPEN_RING_NAME).unwrap();
-    reg.add_ring_to_resource(res_b, "ring_b").unwrap();
-    assert_eq!(
-        reg.list_resource_rings(res_b).unwrap(),
-        vec![Ring::new("ring_b").unwrap()]
-    );
+    reg.add_ring_to_resource(res_b, OPEN_RING_NAME, &[Permission::Read])
+        .unwrap();
+    reg.add_ring_to_resource(res_b, "ring_b", &[Permission::Read])
+        .unwrap();
+    let rings_b = reg.list_resource_rings(res_b).unwrap();
+    assert_eq!(rings_b.len(), 1);
+    assert_eq!(rings_b[0].0, Ring::new("ring_b").unwrap());
 
-    // associating the same ring twice is idempotent
+    // associating the same ring twice updates its permissions
     let res_c = make_resource(0x04);
     reg.create_ring("ring_c").unwrap();
-    reg.add_ring_to_resource(res_c, "ring_c").unwrap();
-    reg.add_ring_to_resource(res_c, "ring_c").unwrap();
-    assert_eq!(reg.list_resource_rings(res_c).unwrap().len(), 1);
+    reg.add_ring_to_resource(res_c, "ring_c", &[Permission::Read])
+        .unwrap();
+    reg.add_ring_to_resource(res_c, "ring_c", &[Permission::Read, Permission::Write])
+        .unwrap();
+    let rings_c = reg.list_resource_rings(res_c).unwrap();
+    assert_eq!(rings_c.len(), 1);
+    assert!(rings_c[0].1.contains(&Permission::Write));
 
     // multiple private rings accumulate
     let res_d = make_resource(0x05);
     reg.create_ring("ring_d").unwrap();
     reg.create_ring("ring_e").unwrap();
-    reg.add_ring_to_resource(res_d, "ring_d").unwrap();
-    reg.add_ring_to_resource(res_d, "ring_e").unwrap();
-    let rings = reg.list_resource_rings(res_d).unwrap();
-    assert_eq!(rings.len(), 2);
-    assert!(rings.contains(&Ring::new("ring_d").unwrap()));
-    assert!(rings.contains(&Ring::new("ring_e").unwrap()));
+    reg.add_ring_to_resource(res_d, "ring_d", &[Permission::Read])
+        .unwrap();
+    reg.add_ring_to_resource(res_d, "ring_e", &[Permission::Read, Permission::Write])
+        .unwrap();
+    let rings_d = reg.list_resource_rings(res_d).unwrap();
+    assert_eq!(rings_d.len(), 2);
+    assert!(rings_d
+        .iter()
+        .any(|(r, _)| r == &Ring::new("ring_d").unwrap()));
+    assert!(rings_d
+        .iter()
+        .any(|(r, _)| r == &Ring::new("ring_e").unwrap()));
 
     // --- nicknames ---
 

--- a/src/transfers/fs.rs
+++ b/src/transfers/fs.rs
@@ -115,6 +115,13 @@ impl<R: Registry + Clone + Send + Sync + 'static> FsTransfer<R> {
 
 impl<R: Registry + Clone + Send + Sync + 'static> Transfer for FsTransfer<R> {
     async fn can_access(&self, peer: &EndpointId, resource_id: &[u8]) -> bool {
+        if self
+            .registry
+            .has_permission(peer, &resource_id.to_vec(), Permission::Read)
+            .unwrap_or(false)
+        {
+            return true;
+        }
         let Ok(hash_bytes) = resource_id.try_into() else {
             return false;
         };

--- a/src/transfers/fs.rs
+++ b/src/transfers/fs.rs
@@ -27,7 +27,7 @@ use iroh_io::AsyncStreamWriter;
 use tracing::instrument;
 
 use crate::protocol::Transfer;
-use crate::registry::Registry;
+use crate::registry::{Permission, Registry};
 
 /// Encode chunk-group ranges into wire bytes:
 ///   [u32-le count] [count × (start u64-le, end u64-le)]
@@ -173,7 +173,7 @@ impl<R: Registry + Clone + Send + Sync + 'static> FsTransfer<R> {
             }
             if !self
                 .registry
-                .is_allowed(peer, info.hash.as_bytes())
+                .has_permission(peer, info.hash.as_bytes(), Permission::Read)
                 .unwrap_or(false)
             {
                 continue;

--- a/tests/gate_integration.rs
+++ b/tests/gate_integration.rs
@@ -1,0 +1,142 @@
+//! Integration tests for [`RingGate`] access-control enforcement.
+//!
+//! Each test spins up a real in-process iroh endpoint pair to exercise the
+//! full wire protocol, verifying that ring membership and
+//! [`iroh_rings::Transfer::can_access`] are both required for access to be
+//! granted (i.e. the gate uses `&&`, not `||`).
+
+#![cfg(feature = "mem")]
+
+use std::collections::BTreeSet;
+
+use anyhow::Result;
+use iroh::{
+    endpoint::{presets, Connection, RecvStream, SendStream},
+    protocol::Router,
+    Endpoint, EndpointAddr, SecretKey, TransportAddr,
+};
+use iroh_rings::{
+    protocol::{encode_request, Status},
+    InMemoryRegistry, Permission, Registry, RingGate, ALPN,
+};
+
+const RESOURCE: &[u8] = b"gate-test-resource";
+
+/// A [`iroh_rings::Transfer`] whose `can_access` verdict is fixed at construction.
+#[derive(Clone)]
+struct FixedTransfer(bool);
+
+impl iroh_rings::Transfer for FixedTransfer {
+    async fn can_access(&self, _peer: &iroh::EndpointId, _resource_id: &[u8]) -> bool {
+        self.0
+    }
+
+    async fn transfer(
+        &self,
+        _resource_id: &[u8],
+        send: &mut SendStream,
+        _recv: &mut RecvStream,
+    ) -> Result<()> {
+        send.write_all(b"ok").await?;
+        Ok(())
+    }
+}
+
+struct Server {
+    addr: EndpointAddr,
+    _router: Router,
+}
+
+/// Starts a server with one ring member registered on `RESOURCE`.
+/// `can_access` controls what `FixedTransfer` returns for every peer.
+async fn start_server(can_access: bool) -> Result<(Server, SecretKey)> {
+    let member_key = SecretKey::generate();
+    let member_id = member_key.public();
+
+    let registry = InMemoryRegistry::new();
+    registry.create_ring("members")?;
+    registry.add_ring_to_resource(RESOURCE.to_vec(), "members", &[Permission::Read])?;
+    registry.add_peer_to_ring("members", member_id, None)?;
+
+    let endpoint = Endpoint::builder(presets::Minimal).bind().await?;
+    let gate = RingGate::new(registry, FixedTransfer(can_access));
+    let router = Router::builder(endpoint.clone()).accept(ALPN, gate).spawn();
+
+    let addr = EndpointAddr {
+        id: endpoint.id(),
+        addrs: endpoint
+            .bound_sockets()
+            .into_iter()
+            .map(TransportAddr::Ip)
+            .collect::<BTreeSet<_>>(),
+    };
+
+    Ok((
+        Server {
+            addr,
+            _router: router,
+        },
+        member_key,
+    ))
+}
+
+/// Connects `endpoint` to `server`, requests `RESOURCE` with Read permission,
+/// and returns `Some(payload)` if ALLOWED or `None` if DENIED.
+async fn fetch(endpoint: &Endpoint, server_addr: EndpointAddr) -> Result<Option<Vec<u8>>> {
+    let conn: Connection = endpoint.connect(server_addr, ALPN).await?;
+    let (mut send, mut recv): (SendStream, RecvStream) = conn.open_bi().await?;
+    send.write_all(&encode_request(RESOURCE, Permission::Read)?)
+        .await?;
+    send.finish()?;
+
+    let mut status = [0u8; 1];
+    recv.read_exact(&mut status).await?;
+    match Status::try_from(status[0])? {
+        Status::Allowed => Ok(Some(recv.read_to_end(1024).await?)),
+        Status::Denied => Ok(None),
+        _ => anyhow::bail!("unexpected status byte: {}", status[0]),
+    }
+}
+
+/// Ring member with can_access=true is allowed.
+#[tokio::test]
+async fn member_with_can_access_true_is_allowed() -> Result<()> {
+    let (server, member_key) = start_server(true).await?;
+    let member = Endpoint::builder(presets::Minimal)
+        .secret_key(member_key)
+        .bind()
+        .await?;
+    assert!(fetch(&member, server.addr).await?.is_some());
+    Ok(())
+}
+
+/// Ring member with can_access=false is denied — both checks must pass.
+#[tokio::test]
+async fn member_with_can_access_false_is_denied() -> Result<()> {
+    let (server, member_key) = start_server(false).await?;
+    let member = Endpoint::builder(presets::Minimal)
+        .secret_key(member_key)
+        .bind()
+        .await?;
+    assert!(fetch(&member, server.addr).await?.is_none());
+    Ok(())
+}
+
+/// Stranger with can_access=true is denied — ring membership is required.
+/// This is the exact case that caught the `||` vs `&&` bug in the gate.
+#[tokio::test]
+async fn stranger_with_can_access_true_is_denied() -> Result<()> {
+    let (server, _) = start_server(true).await?;
+    let stranger = Endpoint::builder(presets::Minimal).bind().await?;
+    assert!(fetch(&stranger, server.addr).await?.is_none());
+    Ok(())
+}
+
+/// Stranger with can_access=false is denied.
+#[tokio::test]
+async fn stranger_with_can_access_false_is_denied() -> Result<()> {
+    let (server, _) = start_server(false).await?;
+    let stranger = Endpoint::builder(presets::Minimal).bind().await?;
+    assert!(fetch(&stranger, server.addr).await?.is_none());
+    Ok(())
+}

--- a/tests/gate_integration.rs
+++ b/tests/gate_integration.rs
@@ -1,9 +1,14 @@
 //! Integration tests for [`RingGate`] access-control enforcement.
 //!
 //! Each test spins up a real in-process iroh endpoint pair to exercise the
-//! full wire protocol, verifying that ring membership and
-//! [`iroh_rings::Transfer::can_access`] are both required for access to be
-//! granted (i.e. the gate uses `&&`, not `||`).
+//! full wire protocol, verifying that the gate grants access when EITHER
+//! [`Registry::has_permission`] OR [`iroh_rings::Transfer::can_access`]
+//! returns true (i.e. the gate uses `||`).
+//!
+//! The `||` design is required so that collection sub-blobs — which are not
+//! directly tagged in the registry but are reachable via an accessible
+//! [`HashSeq`] collection — can be served by [`FsTransfer::can_access`]
+//! without every individual blob needing a registry entry.
 
 #![cfg(feature = "mem")]
 
@@ -110,25 +115,27 @@ async fn member_with_can_access_true_is_allowed() -> Result<()> {
     Ok(())
 }
 
-/// Ring member with can_access=false is denied — both checks must pass.
+/// Ring member with can_access=false is still allowed — ring membership alone suffices.
 #[tokio::test]
-async fn member_with_can_access_false_is_denied() -> Result<()> {
+async fn member_with_can_access_false_is_allowed() -> Result<()> {
     let (server, member_key) = start_server(false).await?;
     let member = Endpoint::builder(presets::Minimal)
         .secret_key(member_key)
         .bind()
         .await?;
-    assert!(fetch(&member, server.addr).await?.is_none());
+    assert!(fetch(&member, server.addr).await?.is_some());
     Ok(())
 }
 
-/// Stranger with can_access=true is denied — ring membership is required.
-/// This is the exact case that caught the `||` vs `&&` bug in the gate.
+/// Stranger with can_access=true is allowed — can_access alone suffices.
+/// This models the collection sub-blob case: the sub-blob is not in the
+/// registry directly, but Transfer::can_access confirms it is reachable via
+/// an accessible collection (which internally verifies ring membership).
 #[tokio::test]
-async fn stranger_with_can_access_true_is_denied() -> Result<()> {
+async fn stranger_with_can_access_true_is_allowed() -> Result<()> {
     let (server, _) = start_server(true).await?;
     let stranger = Endpoint::builder(presets::Minimal).bind().await?;
-    assert!(fetch(&stranger, server.addr).await?.is_none());
+    assert!(fetch(&stranger, server.addr).await?.is_some());
     Ok(())
 }
 


### PR DESCRIPTION
Closes #3

This makes the ring permission model more granular: a {Read, Write, Delete} Relationship-Based Access Control.

Permission on a ring | What the remote peer can do | Constraint
-- | -- | --
READ | Download a resource | Peer is member of an associated ring
WRITE | Push/update a resource into the registry | Peer is member of an associated ring
DELETE | Remove the ring–resource association | Peer is member of an associated ring

Resource destruction (underlying data) is outside the remote permission model. The local node owner implicitly holds all permissions on their own registry.