### PR TITLE
More granular examples with Read, Write, Delete permissions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,15 @@ bytes = { version = "1", optional = true }
 futures-lite = { version = "2", optional = true }
 
 [[example]]
-name = "access_control"
+name = "read"
+required-features = ["mem"]
+
+[[example]]
+name = "write"
+required-features = ["mem"]
+
+[[example]]
+name = "delete"
 required-features = ["mem"]
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -161,14 +161,20 @@ fn satisfies_registry_contract() {
 }
 ```
 
-## Example
+## Examples
 
-A self-contained end-to-end example is in [`examples/access_control.rs`](examples/access_control.rs).
-It spins up one server, one authorized member, and one stranger, and shows the full
-request/response cycle:
+Three self-contained examples in [`examples/`](examples/), one per permission:
+
+| Example | What it shows |
+|---|---|
+| [`read.rs`](examples/read.rs) | Member receives a payload; stranger is denied |
+| [`write.rs`](examples/write.rs) | Member pushes content to the node's store; stranger is denied |
+| [`delete.rs`](examples/delete.rs) | Member removes the ring–resource association; stranger is denied |
 
 ```sh
-cargo run --example access_control --features mem
+cargo run --example read   --features mem
+cargo run --example write  --features mem
+cargo run --example delete --features mem
 ```
 
 ## Contributing

--- a/examples/delete.rs
+++ b/examples/delete.rs
@@ -1,0 +1,138 @@
+//! Demonstrates `Permission::Delete` — removing a ring–resource association remotely.
+//!
+//! Run with:
+//!   cargo run --example delete --features mem
+//!
+//! What this shows:
+//!   1. A "stranger" peer (not in the ring) tries to delete — DENIED.
+//!   2. A "curator" peer (ring member with Delete permission) deletes the
+//!      ring–resource association — ALLOWED.
+//!   3. After deletion, `list_resource_rings` returns empty, confirming access
+//!      has been fully revoked for all peers on that resource.
+//!
+//! Sub-protocol (after the gate sends ALLOWED):
+//!
+//! ```text
+//! node → initiator  [ 2 B]  "ok" acknowledgment (no initiator payload expected)
+//! ```
+
+use anyhow::Result;
+use std::collections::BTreeSet;
+
+use iroh::{
+    endpoint::{presets, Connection, RecvStream, SendStream},
+    protocol::Router,
+    Endpoint, EndpointAddr, EndpointId, SecretKey, TransportAddr,
+};
+use iroh_rings::{
+    protocol::{encode_request, Status},
+    InMemoryRegistry, Permission, Registry, RingGate, ALPN,
+};
+
+const RESOURCE_ID: &[u8] = b"example-doc";
+
+/// Removes the ring–resource association from the registry when access is granted.
+#[derive(Clone)]
+struct DeleteTransfer {
+    registry: InMemoryRegistry,
+}
+
+impl iroh_rings::Transfer for DeleteTransfer {
+    async fn can_access(&self, _peer: &EndpointId, _resource_id: &[u8]) -> bool {
+        // Implementing this is optional; typical use is subranges of a blob
+        // whose ancestor hashes have already been validated by the ring mechanism.
+        false
+    }
+
+    async fn transfer(
+        &self,
+        resource_id: &[u8],
+        send: &mut SendStream,
+        _recv: &mut RecvStream,
+    ) -> Result<()> {
+        self.registry
+            .remove_ring_from_resource(resource_id.to_vec())?;
+        send.write_all(b"ok").await?;
+        Ok(())
+    }
+}
+
+/// Sends a Delete request; returns `true` if ALLOWED.
+async fn delete(endpoint: &Endpoint, node_addr: EndpointAddr, resource_id: &[u8]) -> Result<bool> {
+    let conn: Connection = endpoint.connect(node_addr, ALPN).await?;
+    let (mut send, mut recv): (SendStream, RecvStream) = conn.open_bi().await?;
+
+    send.write_all(&encode_request(resource_id, Permission::Delete)?)
+        .await?;
+    send.finish()?;
+
+    let mut status = [0u8; 1];
+    recv.read_exact(&mut status).await?;
+    match Status::try_from(status[0])? {
+        Status::Allowed => {
+            recv.read_to_end(16).await?; // consume "ok"
+            Ok(true)
+        }
+        Status::Denied => Ok(false),
+        _ => anyhow::bail!("unexpected status byte: {:#04x}", status[0]),
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let curator_key = SecretKey::generate();
+    let curator_id: EndpointId = curator_key.public();
+
+    let registry = InMemoryRegistry::new();
+    registry.create_ring("curators")?;
+    registry.add_ring_to_resource(RESOURCE_ID.to_vec(), "curators", &[Permission::Delete])?;
+    registry.add_peer_to_ring("curators", curator_id, Some("alice"))?;
+
+    let node = Endpoint::builder(presets::Minimal).bind().await?;
+    let transfer = DeleteTransfer {
+        registry: registry.clone(),
+    };
+    let gate = RingGate::new(registry.clone(), transfer);
+    let _router = Router::builder(node.clone()).accept(ALPN, gate).spawn();
+
+    let node_addr = EndpointAddr {
+        id: node.id(),
+        addrs: node
+            .bound_sockets()
+            .into_iter()
+            .map(TransportAddr::Ip)
+            .collect::<BTreeSet<_>>(),
+    };
+
+    println!("node    : {}", node.id());
+    println!("resource: {}", String::from_utf8_lossy(RESOURCE_ID));
+    println!();
+
+    let stranger = Endpoint::builder(presets::Minimal).bind().await?;
+
+    print!("stranger (no ring) … ");
+    match delete(&stranger, node_addr.clone(), RESOURCE_ID).await? {
+        true => println!("ALLOWED (unexpected)"),
+        false => println!("DENIED (expected)"),
+    }
+
+    let curator = Endpoint::builder(presets::Minimal)
+        .secret_key(curator_key)
+        .bind()
+        .await?;
+
+    print!("curator  (in ring) … ");
+    match delete(&curator, node_addr, RESOURCE_ID).await? {
+        true => println!("ALLOWED — ring association removed"),
+        false => println!("DENIED (unexpected)"),
+    }
+
+    let remaining = registry.list_resource_rings(RESOURCE_ID.to_vec())?;
+    println!();
+    println!(
+        "ring associations after delete: {} (access fully revoked)",
+        remaining.len()
+    );
+
+    Ok(())
+}

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -1,10 +1,10 @@
-//! End-to-end example: one server, one authorized member, one stranger.
+//! Demonstrates `Permission::Read` with a fixed in-memory payload.
 //!
 //! Run with:
-//!   cargo run --example access_control --features mem
+//!   cargo run --example read --features mem
 //!
 //! What this shows:
-//!   1. A server creates a ring, associates a resource with Read permission, and
+//!   1. A node creates a ring, associates a resource with Read permission, and
 //!      starts a [`RingGate`]-protected endpoint.
 //!   2. A "member" peer that was added to the ring connects, requests the resource,
 //!      and receives the payload.
@@ -27,7 +27,7 @@ use iroh_rings::{
 // The resource identifier — any stable byte sequence up to 256 bytes.
 const RESOURCE_ID: &[u8] = b"example-document-v1";
 
-// The payload the server sends when access is granted.
+// The payload served when access is granted.
 const CONTENT: &[u8] = b"the content of example-document-v1";
 
 /// A minimal [`iroh_rings::Transfer`] that serves a fixed in-memory payload.
@@ -39,7 +39,9 @@ struct StaticTransfer;
 
 impl iroh_rings::Transfer for StaticTransfer {
     async fn can_access(&self, _peer: &EndpointId, _resource_id: &[u8]) -> bool {
-        true // rely entirely on ring membership; no additional check needed here
+        // Implementing this is optional; typical use is subranges of a blob
+        // whose ancestor hashes have already been validated by the ring mechanism.
+        false
     }
 
     async fn transfer(
@@ -53,10 +55,10 @@ impl iroh_rings::Transfer for StaticTransfer {
     }
 }
 
-/// Connects to `server_addr`, requests `RESOURCE_ID` with `Read` permission,
+/// Connects to `node_addr`, requests `RESOURCE_ID` with `Read` permission,
 /// and returns the payload if access was granted or `None` if denied.
-async fn fetch(endpoint: &Endpoint, server_addr: EndpointAddr) -> Result<Option<Vec<u8>>> {
-    let conn: Connection = endpoint.connect(server_addr, ALPN).await?;
+async fn fetch(endpoint: &Endpoint, node_addr: EndpointAddr) -> Result<Option<Vec<u8>>> {
+    let conn: Connection = endpoint.connect(node_addr, ALPN).await?;
     let (mut send, mut recv): (SendStream, RecvStream) = conn.open_bi().await?;
 
     send.write_all(&encode_request(RESOURCE_ID, Permission::Read)?)
@@ -82,34 +84,27 @@ async fn main() -> Result<()> {
     let member_key = SecretKey::generate();
     let member_id: EndpointId = member_key.public();
 
-    // Server setup
-
     let registry = InMemoryRegistry::new();
-
     registry.create_ring("readers")?;
     registry.add_ring_to_resource(RESOURCE_ID.to_vec(), "readers", &[Permission::Read])?;
     registry.add_peer_to_ring("readers", member_id, Some("alice"))?;
 
-    let server = Endpoint::builder(presets::Minimal).bind().await?;
+    let node = Endpoint::builder(presets::Minimal).bind().await?;
     let gate = RingGate::new(registry, StaticTransfer);
-    let _router = Router::builder(server.clone()).accept(ALPN, gate).spawn();
+    let _router = Router::builder(node.clone()).accept(ALPN, gate).spawn();
 
-    // Build the server's EndpointAddr from its bound local sockets so the
-    // clients can reach it directly without a relay.
-    let server_addr = EndpointAddr {
-        id: server.id(),
-        addrs: server
+    let node_addr = EndpointAddr {
+        id: node.id(),
+        addrs: node
             .bound_sockets()
             .into_iter()
             .map(TransportAddr::Ip)
             .collect::<BTreeSet<_>>(),
     };
 
-    println!("server : {}", server.id());
+    println!("node    : {}", node.id());
     println!("resource: {}", String::from_utf8_lossy(RESOURCE_ID));
     println!();
-
-    // Authorized member
 
     let member = Endpoint::builder(presets::Minimal)
         .secret_key(member_key)
@@ -117,17 +112,15 @@ async fn main() -> Result<()> {
         .await?;
 
     print!("member  (in ring)  … ");
-    match fetch(&member, server_addr.clone()).await? {
+    match fetch(&member, node_addr.clone()).await? {
         Some(data) => println!("ALLOWED — payload: {:?}", String::from_utf8_lossy(&data)),
         None => println!("DENIED (unexpected)"),
     }
 
-    // Stranger (not in the ring)
-
     let stranger = Endpoint::builder(presets::Minimal).bind().await?;
 
     print!("stranger (no ring) … ");
-    match fetch(&stranger, server_addr).await? {
+    match fetch(&stranger, node_addr).await? {
         Some(_) => println!("ALLOWED (unexpected)"),
         None => println!("DENIED (expected)"),
     }

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -1,0 +1,150 @@
+//! Demonstrates `Permission::Write` with a simple push-to-store sub-protocol.
+//!
+//! Run with:
+//!   cargo run --example write --features mem
+//!
+//! What this shows:
+//!   1. A node stores incoming bytes in a shared in-memory map.
+//!   2. A "writer" peer (ring member) pushes content -> access ALLOWED, bytes are stored.
+//!   3. A "stranger" peer (not in the ring) attempts the same push -> access DENIED.
+//!
+//! Sub-protocol (after the gate sends ALLOWED):
+//!
+//! ```text
+//! initiator → node  [rest]  raw content bytes
+//! node → initiator  [ 2 B]  "ok" acknowledgment
+//! ```
+
+use anyhow::Result;
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::{Arc, Mutex},
+};
+
+use iroh::{
+    endpoint::{presets, Connection, RecvStream, SendStream},
+    protocol::Router,
+    Endpoint, EndpointAddr, EndpointId, SecretKey, TransportAddr,
+};
+use iroh_rings::{
+    protocol::{encode_request, Status},
+    InMemoryRegistry, Permission, Registry, RingGate, ALPN,
+};
+
+const RESOURCE_ID: &[u8] = b"example-doc";
+
+/// Receives content bytes over the stream and stores them keyed by resource id.
+#[derive(Clone)]
+struct WriteTransfer {
+    store: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
+}
+
+impl iroh_rings::Transfer for WriteTransfer {
+    async fn can_access(&self, _peer: &EndpointId, _resource_id: &[u8]) -> bool {
+        // Implementing this is optional; typical use is subranges of a blob
+        // whose ancestor hashes have already been validated by the ring mechanism.
+        false
+    }
+
+    async fn transfer(
+        &self,
+        resource_id: &[u8],
+        send: &mut SendStream,
+        recv: &mut RecvStream,
+    ) -> Result<()> {
+        let content = recv.read_to_end(1024 * 1024).await?;
+        self.store
+            .lock()
+            .unwrap()
+            .insert(resource_id.to_vec(), content);
+        send.write_all(b"ok").await?;
+        Ok(())
+    }
+}
+
+/// Pushes `content` to `resource_id` on the node; returns `true` if ALLOWED.
+async fn push(
+    endpoint: &Endpoint,
+    node_addr: EndpointAddr,
+    resource_id: &[u8],
+    content: &[u8],
+) -> Result<bool> {
+    let conn: Connection = endpoint.connect(node_addr, ALPN).await?;
+    let (mut send, mut recv): (SendStream, RecvStream) = conn.open_bi().await?;
+
+    send.write_all(&encode_request(resource_id, Permission::Write)?)
+        .await?;
+    send.write_all(content).await?;
+    send.finish()?;
+
+    let mut status = [0u8; 1];
+    recv.read_exact(&mut status).await?;
+    match Status::try_from(status[0])? {
+        Status::Allowed => {
+            recv.read_to_end(16).await?; // consume "ok"
+            Ok(true)
+        }
+        Status::Denied => Ok(false),
+        _ => anyhow::bail!("unexpected status byte: {:#04x}", status[0]),
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let writer_key = SecretKey::generate();
+    let writer_id: EndpointId = writer_key.public();
+
+    let registry = InMemoryRegistry::new();
+    registry.create_ring("writers")?;
+    registry.add_ring_to_resource(RESOURCE_ID.to_vec(), "writers", &[Permission::Write])?;
+    registry.add_peer_to_ring("writers", writer_id, Some("alice"))?;
+
+    let store: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>> = Arc::new(Mutex::new(HashMap::new()));
+    let transfer = WriteTransfer {
+        store: Arc::clone(&store),
+    };
+
+    let node = Endpoint::builder(presets::Minimal).bind().await?;
+    let gate = RingGate::new(registry, transfer);
+    let _router = Router::builder(node.clone()).accept(ALPN, gate).spawn();
+
+    let node_addr = EndpointAddr {
+        id: node.id(),
+        addrs: node
+            .bound_sockets()
+            .into_iter()
+            .map(TransportAddr::Ip)
+            .collect::<BTreeSet<_>>(),
+    };
+
+    println!("node    : {}", node.id());
+    println!("resource: {}", String::from_utf8_lossy(RESOURCE_ID));
+    println!();
+
+    let writer = Endpoint::builder(presets::Minimal)
+        .secret_key(writer_key)
+        .bind()
+        .await?;
+
+    print!("writer  (in ring)  … ");
+    match push(&writer, node_addr.clone(), RESOURCE_ID, b"hello from alice").await? {
+        true => {
+            let stored = store.lock().unwrap();
+            let content = stored
+                .get(RESOURCE_ID)
+                .map(|v| String::from_utf8_lossy(v).into_owned());
+            println!("ALLOWED — stored: {:?}", content.unwrap_or_default());
+        }
+        false => println!("DENIED (unexpected)"),
+    }
+
+    let stranger = Endpoint::builder(presets::Minimal).bind().await?;
+
+    print!("stranger (no ring) … ");
+    match push(&stranger, node_addr, RESOURCE_ID, b"intruder content").await? {
+        true => println!("ALLOWED (unexpected)"),
+        false => println!("DENIED (expected)"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Examples files have been reorganized to be more explicit in the usage of the ring concept with Read, Write and Delete permissions.
The three use cases are end-to-end actionable.