### PR TITLE
Change resource-to-peer relation name

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%   # tolerate up to 1% project-wide drop
+    patch:
+      default:
+        threshold: 90%  # at least 90% of changed lines must be covered
+
+comment:
+  layout: "diff"
+  require_changes: true  # silent when coverage is unchanged
+  behavior: once         # post once, don't update on every push

--- a/src/backends/memory.rs
+++ b/src/backends/memory.rs
@@ -17,7 +17,7 @@ use crate::Error;
 #[derive(Default)]
 struct Inner {
     rings: HashMap<String, Vec<[u8; 32]>>,
-    nicknames: HashMap<(String, [u8; 32]), String>,
+    labels: HashMap<(String, [u8; 32]), String>,
     /// Maps resource id → ordered list of (ring_name, permissions) pairs.
     resource_rings: HashMap<Vec<u8>, Vec<(String, Vec<Permission>)>>,
 }
@@ -67,7 +67,7 @@ impl Registry for InMemoryRegistry {
         &self,
         ring_name: &str,
         peer: EndpointId,
-        nickname: Option<&str>,
+        label: Option<&str>,
     ) -> Result<(), Error> {
         let mut inner = self.inner.write().unwrap();
         let members = inner
@@ -78,10 +78,10 @@ impl Registry for InMemoryRegistry {
         if !members.contains(&peer_bytes) {
             members.push(peer_bytes);
         }
-        if let Some(nick) = nickname {
+        if let Some(lbl) = label {
             inner
-                .nicknames
-                .insert((ring_name.to_string(), peer_bytes), nick.to_string());
+                .labels
+                .insert((ring_name.to_string(), peer_bytes), lbl.to_string());
         }
         Ok(())
     }
@@ -94,7 +94,7 @@ impl Registry for InMemoryRegistry {
             .ok_or_else(|| Error::RingNotFound(ring_name.to_string()))?;
         let peer_bytes = *peer.as_bytes();
         members.retain(|b| b != &peer_bytes);
-        inner.nicknames.remove(&(ring_name.to_string(), peer_bytes));
+        inner.labels.remove(&(ring_name.to_string(), peer_bytes));
         Ok(())
     }
 
@@ -109,8 +109,8 @@ impl Registry for InMemoryRegistry {
             .map(|b| {
                 let peer = EndpointId::from_bytes(b)
                     .map_err(|e| Error::Storage(Box::new(std::io::Error::other(e.to_string()))))?;
-                let nick = inner.nicknames.get(&(ring_name.to_string(), *b)).cloned();
-                Ok((peer, nick))
+                let label = inner.labels.get(&(ring_name.to_string(), *b)).cloned();
+                Ok((peer, label))
             })
             .collect()
     }

--- a/src/backends/redb/migrations.rs
+++ b/src/backends/redb/migrations.rs
@@ -13,19 +13,23 @@
 //! |---------|--------|
 //! | 0 | Initial schema: `RINGS`, `RESOURCE_RINGS`, `NICKNAMES`. No permission data. |
 //! | 1 | Added `RESOURCE_RING_PERMS`. All existing ring–resource associations are backfilled with `Read` permission. |
+//! | 2 | Renamed `NICKNAMES` table to `LABELS`. All existing rows are copied and the old table is deleted. |
 
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 
 use crate::Error;
 
-use super::{decode_ring_names, perm_key, storage, RESOURCE_RINGS, RESOURCE_RING_PERMS};
+use super::{decode_ring_names, perm_key, storage, LABELS, RESOURCE_RINGS, RESOURCE_RING_PERMS};
 
 /// Stores the single `schema_version` key.
 const META: TableDefinition<&str, u32> = TableDefinition::new("meta");
 const SCHEMA_VERSION_KEY: &str = "schema_version";
 
 /// The schema version this code targets. Bump when adding a new migration step.
-const CURRENT_VERSION: u32 = 1;
+const CURRENT_VERSION: u32 = 2;
+
+/// Legacy table name replaced by [`LABELS`] in schema v2.
+const NICKNAMES_LEGACY: TableDefinition<&[u8], &str> = TableDefinition::new("nicknames");
 
 /// Permission bitfield value for `Read`-only access.
 const READ_BIT: u8 = 0b001;
@@ -46,6 +50,9 @@ pub(super) fn migrate(db: &Database) -> Result<(), Error> {
     }
     if version < 1 {
         v0_to_v1(db)?;
+    }
+    if version < 2 {
+        v1_to_v2(db)?;
     }
     Ok(())
 }
@@ -102,6 +109,52 @@ fn v0_to_v1(db: &Database) -> Result<(), Error> {
         // Bump schema version atomically with the data migration.
         let mut meta = write.open_table(META).map_err(storage)?;
         meta.insert(SCHEMA_VERSION_KEY, 1u32).map_err(storage)?;
+    }
+    write.commit().map_err(storage)?;
+    Ok(())
+}
+
+/// Copy all rows from the legacy `"nicknames"` table into `"labels"`, then
+/// delete the old table. The `"labels"` table is already present because
+/// [`super::RedbRegistry::open`] creates it before calling [`migrate`].
+///
+/// If the old table does not exist (fresh database never at v1 nickname data),
+/// only the version bump is written.
+fn v1_to_v2(db: &Database) -> Result<(), Error> {
+    // Read rows from the old table in an isolated read transaction so we can
+    // delete the table in the subsequent write transaction.
+    let rows: Vec<(Vec<u8>, String)> = {
+        let read = db.begin_read().map_err(storage)?;
+        match read.open_table(NICKNAMES_LEGACY) {
+            Ok(table) => table
+                .iter()
+                .map_err(storage)?
+                .map(|r| {
+                    let (k, v) = r.map_err(storage)?;
+                    Ok((k.value().to_vec(), v.value().to_owned()))
+                })
+                .collect::<Result<_, Error>>()?,
+            Err(redb::TableError::TableDoesNotExist(_)) => Vec::new(),
+            Err(e) => return Err(storage(e)),
+        }
+    };
+
+    let write = db.begin_write().map_err(storage)?;
+    {
+        if !rows.is_empty() {
+            let mut label_table = write.open_table(LABELS).map_err(storage)?;
+            for (key, value) in &rows {
+                label_table
+                    .insert(key.as_slice(), value.as_str())
+                    .map_err(storage)?;
+            }
+        }
+
+        // Returns Ok(false) if the table didn't exist — that's fine.
+        write.delete_table(NICKNAMES_LEGACY).map_err(storage)?;
+
+        let mut meta = write.open_table(META).map_err(storage)?;
+        meta.insert(SCHEMA_VERSION_KEY, 2u32).map_err(storage)?;
     }
     write.commit().map_err(storage)?;
     Ok(())
@@ -200,5 +253,67 @@ mod tests {
         let version_before = read_version(&db).unwrap();
         migrate(&db).unwrap();
         assert_eq!(read_version(&db).unwrap(), version_before);
+    }
+
+    #[test]
+    fn v1_nicknames_get_migrated_to_labels() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.redb");
+
+        let peer_key = iroh::SecretKey::generate();
+        let peer_id = peer_key.public();
+        let ring_name = "friends";
+        let label = "alice";
+
+        // Build a v1 database: old schema + version set to 1 + a nickname row.
+        {
+            let db = open_bare(&path);
+            bootstrap_old_schema(&db);
+            insert_old_association(&db, &[0xabu8; 32], ring_name);
+
+            // Set schema version to 1 and insert a nickname into the old table.
+            let write = db.begin_write().unwrap();
+            {
+                let mut meta = write.open_table(META).unwrap();
+                meta.insert(SCHEMA_VERSION_KEY, 1u32).unwrap();
+
+                let mut nick_table = write
+                    .open_table(TableDefinition::<&[u8], &str>::new("nicknames"))
+                    .unwrap();
+                // Build the key the same way label_key does: ring_name + NUL + peer_id bytes.
+                let mut key = ring_name.as_bytes().to_vec();
+                key.push(b'\0');
+                key.extend_from_slice(peer_id.as_bytes());
+                nick_table.insert(key.as_slice(), label).unwrap();
+            }
+            write.commit().unwrap();
+        }
+
+        // Run migration and verify the label is now in the LABELS table.
+        {
+            let db = open_bare(&path);
+            migrate(&db).unwrap();
+            assert_eq!(read_version(&db).unwrap(), CURRENT_VERSION);
+
+            // Old table must be gone.
+            let read = db.begin_read().unwrap();
+            assert!(matches!(
+                read.open_table(NICKNAMES_LEGACY),
+                Err(redb::TableError::TableDoesNotExist(_))
+            ));
+
+            // New table must contain the migrated row.
+            let label_table = read.open_table(LABELS).unwrap();
+            let mut key = ring_name.as_bytes().to_vec();
+            key.push(b'\0');
+            key.extend_from_slice(peer_id.as_bytes());
+            let stored = label_table
+                .get(key.as_slice())
+                .unwrap()
+                .expect("label row must exist after migration")
+                .value()
+                .to_owned();
+            assert_eq!(stored, label);
+        }
     }
 }

--- a/src/backends/redb/mod.rs
+++ b/src/backends/redb/mod.rs
@@ -5,7 +5,7 @@
 //! ```text
 //! RINGS            ring_name → flat-concatenated peer-id bytes (32 B each)
 //! RESOURCE_RINGS   resource_id → NUL-separated ring names
-//! NICKNAMES        ring_name\0peer_id → display label (UTF-8)
+//! LABELS           ring_name\0peer_id → display label (UTF-8)
 //! RESOURCE_RING_PERMS  [2B len][resource_id][ring_name] → permission bitfield (u8)
 //! ```
 //!
@@ -43,9 +43,9 @@ const RINGS: TableDefinition<&str, &[u8]> = TableDefinition::new("rings");
 /// Maps resource unique ids (bytes) to NUL-separated ring names.
 const RESOURCE_RINGS: TableDefinition<&[u8], &[u8]> = TableDefinition::new("resource_rings");
 
-/// Maps `ring_name \0 peer_id_bytes` to nickname string (display label only).
+/// Maps `ring_name \0 peer_id_bytes` to label string (display label only).
 /// Ring names are validated to contain no NUL, so the separator is unambiguous.
-const NICKNAMES: TableDefinition<&[u8], &str> = TableDefinition::new("nicknames");
+const LABELS: TableDefinition<&[u8], &str> = TableDefinition::new("labels");
 
 /// Maps a composite key `[2B resource_id_len_le][resource_id][ring_name]` to a
 /// permission bitfield (`u8`): bit 0 = Read, bit 1 = Write, bit 2 = Delete.
@@ -73,7 +73,7 @@ impl RedbRegistry {
         {
             let mut rings = write.open_table(RINGS).map_err(storage)?;
             write.open_table(RESOURCE_RINGS).map_err(storage)?;
-            write.open_table(NICKNAMES).map_err(storage)?;
+            write.open_table(LABELS).map_err(storage)?;
             write.open_table(RESOURCE_RING_PERMS).map_err(storage)?;
 
             if rings.get(OPEN_RING_NAME).map_err(storage)?.is_none() {
@@ -112,7 +112,7 @@ impl Registry for RedbRegistry {
         &self,
         ring_name: &str,
         peer: EndpointId,
-        nickname: Option<&str>,
+        label: Option<&str>,
     ) -> Result<(), Error> {
         let write = self.db.begin_write().map_err(storage)?;
         {
@@ -129,10 +129,10 @@ impl Registry for RedbRegistry {
                 .insert(ring_name, encode_peer_ids(&members).as_slice())
                 .map_err(storage)?;
 
-            if let Some(nick) = nickname {
-                let mut nick_table = write.open_table(NICKNAMES).map_err(storage)?;
-                nick_table
-                    .insert(nickname_key(ring_name, &peer).as_slice(), nick)
+            if let Some(lbl) = label {
+                let mut label_table = write.open_table(LABELS).map_err(storage)?;
+                label_table
+                    .insert(label_key(ring_name, &peer).as_slice(), lbl)
                     .map_err(storage)?;
             }
         }
@@ -154,9 +154,9 @@ impl Registry for RedbRegistry {
                 .insert(ring_name, encode_peer_ids(&members).as_slice())
                 .map_err(storage)?;
 
-            let mut nick_table = write.open_table(NICKNAMES).map_err(storage)?;
-            nick_table
-                .remove(nickname_key(ring_name, &peer).as_slice())
+            let mut label_table = write.open_table(LABELS).map_err(storage)?;
+            label_table
+                .remove(label_key(ring_name, &peer).as_slice())
                 .map_err(storage)?;
         }
         write.commit().map_err(storage)?;
@@ -166,7 +166,7 @@ impl Registry for RedbRegistry {
     fn list_ring_peers(&self, ring_name: &str) -> Result<Vec<(EndpointId, Option<String>)>, Error> {
         let read = self.db.begin_read().map_err(storage)?;
         let table = read.open_table(RINGS).map_err(storage)?;
-        let nick_table = read.open_table(NICKNAMES).map_err(storage)?;
+        let label_table = read.open_table(LABELS).map_err(storage)?;
         match table.get(ring_name).map_err(storage)? {
             None => Err(Error::RingNotFound(ring_name.to_string())),
             Some(v) => decode_peer_ids(v.value())
@@ -175,11 +175,11 @@ impl Registry for RedbRegistry {
                     let peer = EndpointId::from_bytes(&b).map_err(|e| {
                         Error::Storage(Box::new(std::io::Error::other(e.to_string())))
                     })?;
-                    let nick = nick_table
-                        .get(nickname_key(ring_name, &peer).as_slice())
+                    let label = label_table
+                        .get(label_key(ring_name, &peer).as_slice())
                         .map_err(storage)?
                         .map(|v| v.value().to_owned());
-                    Ok((peer, nick))
+                    Ok((peer, label))
                 })
                 .collect(),
         }
@@ -374,10 +374,10 @@ impl Registry for RedbRegistry {
     }
 }
 
-// The same peer can have a different nickname in each ring.
-// This is intentional, the label is a per-ring social convention,
+// The same peer can have a different label in each ring.
+// This is intentional: the label is a per-ring social convention,
 // not a global identity as the peer-id is.
-fn nickname_key(ring_name: &str, peer: &EndpointId) -> Vec<u8> {
+fn label_key(ring_name: &str, peer: &EndpointId) -> Vec<u8> {
     let mut key = ring_name.as_bytes().to_vec();
     key.push(b'\0');
     key.extend_from_slice(peer.as_bytes());

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -120,8 +120,8 @@ pub trait Registry {
 
     /// Adds a peer to a ring.
     ///
-    /// Idempotent: if the peer is already a member, only the nickname is
-    /// updated when `nickname` is `Some`.
+    /// Idempotent: if the peer is already a member, only the label is
+    /// updated when `label` is `Some`.
     ///
     /// # Errors
     ///
@@ -131,7 +131,7 @@ pub trait Registry {
         &self,
         ring_name: &str,
         peer: EndpointId,
-        nickname: Option<&str>,
+        label: Option<&str>,
     ) -> Result<(), Error>;
 
     /// Removes a peer from a ring.
@@ -144,7 +144,7 @@ pub trait Registry {
     /// [`Error::Storage`] on a backend I/O failure.
     fn remove_peer_from_ring(&self, ring_name: &str, peer: EndpointId) -> Result<(), Error>;
 
-    /// Returns all `(peer, nickname)` pairs in the ring.
+    /// Returns all `(peer, label)` pairs in the ring.
     ///
     /// # Errors
     ///
@@ -501,46 +501,51 @@ pub fn registry_contract<R: Registry>(reg: &R) {
         "survival_a Read permission must survive adding survival_b to the same resource",
     );
 
-    // --- nicknames ---
+    // --- labels ---
 
-    let nick_peer = make_peer();
-    let no_nick_peer = make_peer();
+    let labeled_peer = make_peer();
+    let unlabeled_peer = make_peer();
     reg.create_ring("nick_ring").unwrap();
 
-    reg.add_peer_to_ring("nick_ring", nick_peer, Some("alice"))
+    reg.add_peer_to_ring("nick_ring", labeled_peer, Some("alice"))
         .unwrap();
     let members = reg.list_ring_peers("nick_ring").unwrap();
     assert_eq!(members.len(), 1);
     assert_eq!(members[0].1.as_deref(), Some("alice"));
 
-    reg.add_peer_to_ring("nick_ring", no_nick_peer, None)
+    reg.add_peer_to_ring("nick_ring", unlabeled_peer, None)
         .unwrap();
     let found = reg.list_ring_peers("nick_ring").unwrap();
     assert_eq!(
-        found.iter().find(|(p, _)| p == &no_nick_peer).unwrap().1,
+        found.iter().find(|(p, _)| p == &unlabeled_peer).unwrap().1,
         None
     );
 
-    reg.add_peer_to_ring("nick_ring", nick_peer, Some("alice2"))
-        .unwrap(); // update nickname
+    reg.add_peer_to_ring("nick_ring", labeled_peer, Some("alice2"))
+        .unwrap(); // update label
     let members = reg.list_ring_peers("nick_ring").unwrap();
     assert_eq!(members.len(), 2);
     assert_eq!(
         members
             .iter()
-            .find(|(p, _)| p == &nick_peer)
+            .find(|(p, _)| p == &labeled_peer)
             .unwrap()
             .1
             .as_deref(),
         Some("alice2")
     );
 
-    reg.remove_peer_from_ring("nick_ring", nick_peer).unwrap();
-    reg.add_peer_to_ring("nick_ring", nick_peer, None).unwrap(); // nickname cleared on removal
+    reg.remove_peer_from_ring("nick_ring", labeled_peer)
+        .unwrap();
+    reg.add_peer_to_ring("nick_ring", labeled_peer, None)
+        .unwrap(); // label cleared on removal
     let found = reg.list_ring_peers("nick_ring").unwrap();
-    assert_eq!(found.iter().find(|(p, _)| p == &nick_peer).unwrap().1, None);
+    assert_eq!(
+        found.iter().find(|(p, _)| p == &labeled_peer).unwrap().1,
+        None
+    );
 
-    // same peer can have different nicknames in different rings
+    // same peer can have different labels in different rings
     let cross_peer = make_peer();
     reg.create_ring("nick_ring2").unwrap();
     reg.add_peer_to_ring("nick_ring", cross_peer, Some("name_a"))
@@ -566,13 +571,13 @@ pub fn registry_contract<R: Registry>(reg: &R) {
         Some("name_b")
     );
 
-    // members with and without nicknames coexist in the same ring
-    let nicks: Vec<_> = reg
+    // members with and without labels coexist in the same ring
+    let labels: Vec<_> = reg
         .list_ring_peers("nick_ring")
         .unwrap()
         .into_iter()
         .map(|(_, n)| n)
         .collect();
-    assert!(nicks.iter().any(|n| n.as_deref() == Some("name_a")));
-    assert!(nicks.iter().any(|n| n.is_none()));
+    assert!(labels.iter().any(|n| n.as_deref() == Some("name_a")));
+    assert!(labels.iter().any(|n| n.is_none()));
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -262,7 +262,7 @@ pub fn registry_contract<R: Registry>(reg: &R) {
         iroh::SecretKey::generate().public()
     }
 
-    // --- list_rings / create_ring ---
+    // list_rings / create_ring
 
     assert!(reg.list_rings().unwrap().iter().any(|r| r.is_open()));
 
@@ -286,7 +286,7 @@ pub fn registry_contract<R: Registry>(reg: &R) {
     assert!(rings.iter().any(|r| r.as_str() == "work"));
     assert_eq!(rings.len(), 3); // open + friends + work
 
-    // --- add_peer_to_ring / remove_peer_from_ring / list_ring_peers ---
+    // add_peer_to_ring / remove_peer_from_ring / list_ring_peers
 
     let alice = make_peer();
     reg.add_peer_to_ring("friends", alice, Some("alice"))
@@ -309,7 +309,7 @@ pub fn registry_contract<R: Registry>(reg: &R) {
     reg.remove_peer_from_ring("friends", extra).unwrap(); // noop when not a member
     assert_eq!(reg.list_ring_peers("friends").unwrap().len(), 0);
 
-    // --- has_permission ---
+    // has_permission
 
     let resource = make_resource(0xab);
     let bob = make_peer();
@@ -383,7 +383,7 @@ pub fn registry_contract<R: Registry>(reg: &R) {
         .add_ring_to_resource(make_resource(0xac), "friends", &[])
         .is_err());
 
-    // --- resource–ring association semantics ---
+    // resource–ring association semantics
 
     assert_eq!(
         reg.list_resource_rings(make_resource(0xfe)).unwrap(),
@@ -501,7 +501,7 @@ pub fn registry_contract<R: Registry>(reg: &R) {
         "survival_a Read permission must survive adding survival_b to the same resource",
     );
 
-    // --- labels ---
+    // labels
 
     let labeled_peer = make_peer();
     let unlabeled_peer = make_peer();


### PR DESCRIPTION
Closes #18 

Changes:
- Refactor from `nickname` to `label` throughout the codebase;
- Addof a Redb migration, from v1 -> v2 to port the existing data.

:point_right:  Note: `add_peer_to_ring` parameter is part of the **public** `Registry` trait, so renaming it from `nickname` to `label` is a semver-breaking change. 